### PR TITLE
add member-only notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,9 @@
           <ul>
             <li><a href="https://www.w3.org/2015/Talks/1217-github-w3c/">Using
                 GitHub for W3C Specifications</a>, Philippe Le Hégaret, 17
-              December 2015 (<a href="https://www.w3.org/2015/12/17-git-minutes">Minutes</a>.</li>
+              December 2015 (<a href="https://www.w3.org/2015/12/17-git-minutes">Minutes</a>).</li>
             <li><a href="https://lists.w3.org/Archives/Member/chairs/2015OctDec/0020.html">Horizontal
-                Review</a>, Virginie Galindo, 13 October 2015 (<a href="https://www.w3.org/2015/10/13-chairing-minutes.html">Minutes</a>,
+                Review</a> (Member-only), Virginie Galindo, 13 October 2015 (<a href="https://www.w3.org/2015/10/13-chairing-minutes.html">Minutes</a>,
               <a href="http://media.w3.org/2015/10/chair-training-horizontal-review">recording</a>)
               and 20 October 2015(<a href="https://www.w3.org/2015/10/20-chairing-minutes.html">Minutes</a>)
               <a href="https://www.w3.org/2015/10/W3C-transversal-review-101_13OCT2015.pptx">slides
@@ -48,12 +48,12 @@
                 in PDF</a>] - See also <a href="https://www.w3.org/blog/2015/11/better-specifications-for-the-sake-of-the-web/">Blog
                 post</a> for keeping your reviewer on track.</li>
             <li><a href="https://lists.w3.org/Archives/Member/chairs/2015JanMar/0009.html">Focus
-                and Productivity</a>, Arnaud Le Hors, 29 January 2015 (<a href="https://www.w3.org/2015/01/29-chairing-minutes.html">minutes</a>,
+                and Productivity</a> (Member-only), Arnaud Le Hors, 29 January 2015 (<a href="https://www.w3.org/2015/01/29-chairing-minutes.html">minutes</a>,
               <a href="http://media.w3.org/2015/01/chair-training-session-4">recording</a>)</li>
             <li><a href="https://lists.w3.org/Archives/Member/chairs/2014OctDec/att-0093/Chair_Training_-_Productivity_20141021.pdf">Focus
-                and Productivity</a>, by Arnaud Le Hors, 23 October 2014 (<a href="https://www.w3.org/2014/10/23-chairing-minutes">minutes</a>)</li>
+                and Productivity</a> (Member-only), by Arnaud Le Hors, 23 October 2014 (<a href="https://www.w3.org/2014/10/23-chairing-minutes">minutes</a>)</li>
             <li><a href="https://lists.w3.org/Archives/Member/chairs/2014AprJun/0136.html">The
-                Human Dimension</a>, Charles McCathie Nevile, 17 June 2014 (<a href="https://www.w3.org/2014/06/17-chairing-minutes.html">minutes</a>)</li>
+                Human Dimension</a> (Member-only), Charles McCathie Nevile, 17 June 2014 (<a href="https://www.w3.org/2014/06/17-chairing-minutes.html">minutes</a>)</li>
             <li><a href="https://www.w3.org/2014/Talks/0423-tools-rrs/">Tools</a>,
               Ralph Swick, Thursday, 24 April 2014, 10-noon ET (<a href="https://www.w3.org/2014/04/24-chairing-minutes">minutes</a>)</li>
             <li><a href="https://www.w3.org/2014/Talks/chairs-part4/">The ABCs
@@ -67,7 +67,7 @@
       <h4 id="current">Current and Upcoming</h4>
       <ul>
         <li>Moratoria: <a href="https://lists.w3.org/Archives/Member/chairs/2017AprJun/0083.html">2nd
-            half of 2017</a>
+            half of 2017</a> (Member-only)
           <ul>
             <li>TPAC 2017: November 6-10</li>
             <li>End of Year: December 18 - January 1</li>
@@ -94,6 +94,7 @@
     </div>
     <div class="left" style="margin-top: 1em">
       <h3 id="news">News for Chairs, Team Contacts and Editors</h3>
+      <p><strong>Note:</strong> The following information in this section is W3C Member-only.</p>
       <ul>
         <li>2017-08-07: <a href="https://lists.w3.org/Archives/Member/chairs/2017JulSep/0071.html">Patent Policy Errata Incorporated - W3C Patent Policy, 5 February 2004 (updated 1 August 2017)</a></li>
         <li>2017-08-04: <a href="https://lists.w3.org/Archives/Member/chairs/2017JulSep/0067.html">Upcoming changes for W3C reports and our /TR pages</a></li>
@@ -394,7 +395,7 @@
             Repository Manager</a>: One interface to find all group github
           contributors and the IPR status</li>
         <li><a href="https://lists.w3.org/Archives/Member/chairs/2016OctDec/0100.html">Github
-            repo activity digest</a></li>
+            repo activity digest</a> (Member-only)</li>
       </ul>
     </div>
     <div class="left" style="width: 48%">
@@ -402,7 +403,7 @@
       <ul>
         <li><a href="chair/role.html">Chair's role</a>; <a href="https://www.w3.org/wiki/MultipleChairs">Guidance
             for Multiple Chairs</a>; <a href="https://www.w3.org/Guide/reagles-experiences.html">On
-            Chairing a group (Member-only)</a></li>
+            Chairing a group</a> (Member-only)</li>
         <li><a href="https://lists.w3.org/Archives/Member/chairs/1999JanMar/0056">Editor's
             role</a> (Member-only though could be made public)</li>
         <li><a href="https://www.w3.org/Signature/Contributor.html">Editor,


### PR DESCRIPTION
I've added general note saying "The following information in this section is W3C Member-only." to the "News for Chairs, Team Contacts and Editors" section of the index.html file. Also added "(Member-only)" notes to all the Member-only links which didn't have the notes.

In addition, added a missing closing parenthesis ")" to "17 December 2015 (Minutes."