### PR TITLE
Point readers to projects related to WG-page development

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ Documentation on how to participate in W3C WGs is split between multiple wikipag
   * Guidance on where to go to receive regional support (e.g. Keio office for Japanese assistance)
 * /participate/teamcontact
   * Guidance on the role of the team contact, and what to expect from them.
+* [/participant/resources](tree/master/participant)
+  * Onboarding Information for Group Participants

--- a/participant/resources.md
+++ b/participant/resources.md
@@ -1,29 +1,32 @@
 # Onboarding Information for Group Participants
 
-# Group Specific Information
+## Group Specific Information
 * Your group's Email list and its archive
 * Your group's WebEx coordinate for group calls
 * Your group's IRC channel
 * Your group's meetings
 * Your group's GitHub repository
 
-**NOTE:**
+**NOTES:**
 * How to identify/get group specific information?
 * Maybe we could use a table to specify group specific resources, e.g., group pages, wikis, ML, WebEx coordinate, IRC, and GitHub repo.
+* It is encouraged to reuse our [generic page template](https://w3c.github.io/design/templates/), the
+  [WG-specific template](https://w3c.github.io/design/wg-homepage/) and projects such as [the public API](https://github.com/w3c/w3c-api) and
+  [Apiary](https://github.com/w3c/apiary/) (contact the Systeam if in doubt about how to proceed).
 
-# General Information
+## General Information
 
-## List of the W3C groups
+### List of the W3C groups
 * [Working Groups/Interest Groups](https://www.w3.org/Member/Groups/)
 * [Business Groups/Community Groups](https://www.w3.org/community/groups/)
 
-## How to join/leave the group
+### How to join/leave the group
 * [Create your W3C account first](https://www.w3.org/accounts/request)
 * Ask your AC to join W3C groups and nominate you as a group participant:
   * [Working Groups/Interest Groups](https://www.w3.org/2004/01/pp-impl/)
   * [Business Groups/Community Groups](https://www.w3.org/community/groups/)
 
-## Emails
+### Emails
 * Email archives:
   * [Public lists](https://lists.w3.org/)
   * [Member lists](https://lists.w3.org/Archives/Member/)
@@ -31,7 +34,7 @@
   * [Mailing list guide](https://www.w3.org/Mail/)
   * [Mailinglist subscription](https://www.w3.org/Mail/Request)
 
-## Teleconfs
+### Teleconfs
 * WebEx:
   * [WebEx best practices](https://www.w3.org/2006/tools/wiki/WebExBestPractices)
   * [WebEx FAQ](https://www.w3.org/2006/tools/wiki/WebExFAQ)
@@ -40,20 +43,19 @@
   * [Zakim HOWTO](https://www.w3.org/2001/12/zakim-irc-bot.html)
   * [RRSAGent HOWTO](https://www.w3.org/2002/03/RRSAgent)
 
-## Meetings
+### Meetings
 * [W3C Member meetings](https://www.w3.org/participate/meetings.html)
 * [TPAC (Techincal Plenary and Advisory Committee Meetings)](https://www.w3.org/2002/09/TPOverview.html)
 * [AC Meeting (Advisory Committee meeting)](https://www.w3.org/Member/Meeting/)
 
-## GitHub
+### GitHub
 * Initial instructions for GitHub beginners:
   * [W3C Specs on GitHub](https://w3c.github.io/specs.html)
   * [W3C Tools Support Wiki](https://www.w3.org/2006/tools/wiki/Github)
 
-## Patent Policy (especially for WGs)
+### Patent Policy (especially for WGs)
 * [W3C Patent Policy (5 February 2004)](https://www.w3.org/Consortium/Patent-Policy-20040205/)
 * [Patent Policy FAQ](https://www.w3.org/2003/12/22-pp-faq.html)
 
-# Learn more
+## Learn more
 * [/Guide](https://www.w3.org/Guide/)
-


### PR DESCRIPTION
* Add to `participant/resources.md` mentions and hyperlinks to &ldquo;new&rdquo; projects that are related to WG-page development and maintenance
* Add to the list on `README.md` an entry about `participant/resources.md` (it was missing)
* While at it, correct outline of `participant/resources.md` (I take it that &ldquo;Onboarding Information for Group Participants&rdquo; is the title of the page, not a sibling of &ldquo;Group Specific Information&rdquo; and &ldquo;General Information&rdquo;)

Some things I don't understand:

* Why the redundancy with `participant/resources.md` and `participant/resources.html` (here I have edited only the former)? Which one is &ldquo;the source&rdquo;? And how is the other one generated? (Please don't tell me we're keeping the same content in two different formats, and syncing them *by hand*&hellip; :)
* Shouldn't all list items in `README.md` point to their respective pages, to facilitate navigation within the repo?