### PR TITLE
Echidna now supports Candidate Recommendations

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
       <h3 id="news">News for Chairs, Team Contacts and Editors</h3>
       <p><strong>Note:</strong> The following information in this section is W3C Member-only.</p>
       <ul>
+        <li>2018-07-02: <a href="https://github.com/w3c/echidna/wiki/CR-publication-workflow">Echidna now supports Candidate Recommendations</a></li>
         <li>2018-06-07: <a href="https://lists.w3.org/Archives/Member/chairs/2018AprJun/0089.html">Publication moratoria for second half of 2018</a></li>
         <li>2018-01-17: <a href="https://lists.w3.org/Archives/Member/chairs/2018JanMar/0012.html">Three things I wish I knew before becoming a chair</a></li>
         <li>2017-12-21: <a href="https://lists.w3.org/Archives/Member/chairs/2017OctDec/0208.html">Happy holidays from W3C!</a></li>


### PR DESCRIPTION
Mention it in the [News for Chairs, Team Contacts and Editors](https://www.w3.org/Guide/#news) section.