### PR TITLE
Information Architecture in /mock

### DIFF
--- a/mock/chairs/advice.md
+++ b/mock/chairs/advice.md
@@ -10,8 +10,8 @@
 ### Advice
 @todo break this down.
 
-### CSI
-Link to CSI doc.
+### Common Standards Issues 
+Link to [Common Standards Issues Document](https://github.com/w3c/wg-effectiveness/blob/master/CSI.md)
 
 ### Getting help from the Team
 plh?

--- a/mock/chairs/advice.md
+++ b/mock/chairs/advice.md
@@ -2,7 +2,7 @@
 * [Advice](#advice)
 * [CSI](#csi)
 * [Getting help from the Team](#getting-help-from-the-team)
-* [Back to Chairs](../index.md#)
+* [<- Back to Chairs](../index.md#)
 
 # Content
 ## Guidelines and Advice for Running a Group

--- a/mock/chairs/advice.md
+++ b/mock/chairs/advice.md
@@ -2,7 +2,7 @@
 * [Advice](#advice)
 * [CSI](#csi)
 * [Getting help from the Team](#getting-help-from-the-team)
-* [<- Back to Chairs](../index.md#)
+* [<- Back to **Chairs**](../index.md#)
 
 # Content
 ## Guidelines and Advice for Running a Group

--- a/mock/chairs/advice.md
+++ b/mock/chairs/advice.md
@@ -1,7 +1,7 @@
 # Menu
 * [Advice](#advice)
 * [CSI](#csi)
-* [CSI](#csi)
+* [Getting help from the Team](#getting-help-from-the-team)
 * [Back to Chairs](../index.md#)
 
 # Content

--- a/mock/chairs/advice.md
+++ b/mock/chairs/advice.md
@@ -10,6 +10,9 @@
 ### Advice
 @todo break this down.
 
+### CSI
+Link to CSI doc.
+
 ### Getting help from the Team
 plh?
 

--- a/mock/chairs/advice.md
+++ b/mock/chairs/advice.md
@@ -1,0 +1,15 @@
+# Menu
+* [Advice](#advice)
+* [CSI](#csi)
+* [CSI](#csi)
+* [Back to Chairs](../index.md#)
+
+# Content
+## Guidelines and Advice for Running a Group
+
+### Advice
+@todo break this down.
+
+### Getting help from the Team
+plh?
+

--- a/mock/chairs/advice.md
+++ b/mock/chairs/advice.md
@@ -1,12 +1,12 @@
-# Menu
+# Guidelines and Advice for Running a Group
+
+## Menu
 * [Advice](#advice)
 * [CSI](#csi)
 * [Getting help from the Team](#getting-help-from-the-team)
 * [<- Back to **Chairs**](index.md#)
 
-# Content
-## Guidelines and Advice for Running a Group
-
+## Content
 ### Advice
 @todo break this down.
 

--- a/mock/chairs/advice.md
+++ b/mock/chairs/advice.md
@@ -2,7 +2,7 @@
 * [Advice](#advice)
 * [CSI](#csi)
 * [Getting help from the Team](#getting-help-from-the-team)
-* [<- Back to **Chairs**](../index.md#)
+* [<- Back to **Chairs**](index.md#)
 
 # Content
 ## Guidelines and Advice for Running a Group

--- a/mock/chairs/buddysystem.md
+++ b/mock/chairs/buddysystem.md
@@ -1,0 +1,8 @@
+# Chair Buddy System
+## Menu
+* [<- Back to **Chairs**](index.md#)
+
+## Content
+Take and modify content from <https://www.w3.org/Guide/chair/buddy.html>
+
+REDIRECT NEEDED: <https://www.w3.org/Guide/chair/buddy.html> will redirect here.

--- a/mock/chairs/index.md
+++ b/mock/chairs/index.md
@@ -4,7 +4,7 @@
 * [Meetings](meetings.md)
 * [Tools For Running a WG / IG](tools.md)
 * [Guidelines and Advice for Running a Group](advice.md)
-* [Starting a Group](#)
+* [Starting a Group](starting_a_group.md)
 * [Chair Buddy System](#)
 * [Rec Track](#) (external link)
 * [<- Back to **Home**](../index.md#)

--- a/mock/chairs/index.md
+++ b/mock/chairs/index.md
@@ -1,7 +1,7 @@
 # Menu
 * [Meetings](https://github.com/nrooney/Guide/blob/master/mock/chairs/meetings.md)
 * [Tools For Running a WG / IG](https://github.com/nrooney/Guide/blob/master/mock/chairs/tools.md)
-* [Guidelines and Advice for Running a Group](#)
+* [Guidelines and Advice for Running a Group](advice.md)
 * [Starting a Group](#)
 * [Chair Buddy System](#)
 * [Rec Track](#) (external link)

--- a/mock/chairs/index.md
+++ b/mock/chairs/index.md
@@ -13,5 +13,7 @@ Here find all the information you need on being a chair of a W3C Working or Busi
 ### Chair Buddy System
 Take and modify content from <https://www.w3.org/Guide/chair/buddy.html>
 
+REDIRECT NEEDED: <https://www.w3.org/Guide/chair/buddy.html> will redirect here.
+
 ### Hot Links
 

--- a/mock/chairs/index.md
+++ b/mock/chairs/index.md
@@ -5,17 +5,12 @@
 * [Tools For Running a WG / IG](tools.md)
 * [Guidelines and Advice for Running a Group](advice.md)
 * [Starting a Group](starting_a_group.md)
-* [Chair Buddy System](#)
+* [Chair Buddy System](buddysystem.md)
 * [Rec Track](#) (external link)
 * [<- Back to **Home**](../index.md#)
 
 ## Content
 Here find all the information you need on being a chair of a W3C Working or Business Group.
 
-### Chair Buddy System
-Take and modify content from <https://www.w3.org/Guide/chair/buddy.html>
-
-REDIRECT NEEDED: <https://www.w3.org/Guide/chair/buddy.html> will redirect here.
-
 ### Hot Links
-
+Add Content

--- a/mock/chairs/index.md
+++ b/mock/chairs/index.md
@@ -1,6 +1,6 @@
 # Menu
-* [Meetings](https://github.com/nrooney/Guide/blob/master/mock/chairs/meetings.md)
-* [Tools For Running a WG / IG](https://github.com/nrooney/Guide/blob/master/mock/chairs/tools.md)
+* [Meetings](meetings.md)
+* [Tools For Running a WG / IG](tools.md)
 * [Guidelines and Advice for Running a Group](advice.md)
 * [Starting a Group](#)
 * [Chair Buddy System](#)

--- a/mock/chairs/index.md
+++ b/mock/chairs/index.md
@@ -10,8 +10,8 @@
 ## Information For Chairs
 Here find all the information you need on being a chair of a W3C Working or Business Group.
 
-## Chair Buddy System
+### Chair Buddy System
 Take and modify content from <https://www.w3.org/Guide/chair/buddy.html>
 
-## Hot Links
+### Hot Links
 

--- a/mock/chairs/index.md
+++ b/mock/chairs/index.md
@@ -6,7 +6,7 @@
 * [Guidelines and Advice for Running a Group](advice.md)
 * [Starting a Group](starting_a_group.md)
 * [Chair Buddy System](buddysystem.md)
-* [Rec Track](#) (external link)
+* [Rec Track](#) (link to another section of /guide)
 * [<- Back to **Home**](../index.md#)
 
 ## Content

--- a/mock/chairs/index.md
+++ b/mock/chairs/index.md
@@ -1,13 +1,15 @@
-# Menu
+# Information For Chairs
+
+## Menu
 * [Meetings](meetings.md)
 * [Tools For Running a WG / IG](tools.md)
 * [Guidelines and Advice for Running a Group](advice.md)
 * [Starting a Group](#)
 * [Chair Buddy System](#)
 * [Rec Track](#) (external link)
+* [<- Back to **Home**](../index.md#)
 
-# Content
-## Information For Chairs
+## Content
 Here find all the information you need on being a chair of a W3C Working or Business Group.
 
 ### Chair Buddy System

--- a/mock/chairs/meetings.md
+++ b/mock/chairs/meetings.md
@@ -1,4 +1,4 @@
-## Meetings
+# Meetings
 ## Menu
 * [Quick start guide](#)
 * [Setting Up Teleconfs](#)

--- a/mock/chairs/meetings.md
+++ b/mock/chairs/meetings.md
@@ -1,22 +1,21 @@
 # Meetings
 ## Menu
-* [Quick start guide](#)
-* [Setting Up Teleconfs](#)
-* [Face-to-Face Meetings](#)
+* [Quick start guide](#) (below)
+* [Setting Up Teleconfs](#) (below)
+* [Face-to-Face Meetings](#) (below)
 * [IRC / Scribing](#) (link to other section)
 * [<- Back to **Chairs**](index.md#)
 
 ## Content
 Information on managing and running meetings.
 
-### Sections
-#### Quick start guide for setting up tools for managing an agenda, generating minutes, and updating issues lists
+### Quick start guide for setting up tools for managing an agenda, generating minutes, and updating issues lists
 Take and modify content from <http://dev.w3.org/2002/scribe/scribedoc.htm#Quick_Start_Guide>
 
-#### Setting up Teleconferences
+### Setting up Teleconferences
 Take and modify content from <https://www.w3.org/Guide/1998/08/TeleconferenceHowTo>
 
-#### Host a face-to-face meeting 
+### Host a face-to-face meeting 
 Take and modify content from  <https://www.w3.org/participate/eventscal>, 
 <https://www.w3.org/Guide/meetings/hosting.htm>, 
 <https://www.w3.org/2004/06/NoNDAPolicy.html>, 

--- a/mock/chairs/meetings.md
+++ b/mock/chairs/meetings.md
@@ -1,11 +1,12 @@
-# Menu
+## Meetings
+## Menu
 * [Quick start guide](#)
 * [Setting Up Teleconfs](#)
 * [Face-to-Face Meetings](#)
 * [IRC / Scribing](#) (link to other section)
+* [<- Back to **Chairs**](index.md#)
 
-# Content
-## Meetings
+## Content
 Information on managing and running meetings.
 
 ### Sections

--- a/mock/chairs/starting_a_group.md
+++ b/mock/chairs/starting_a_group.md
@@ -18,6 +18,12 @@ Add content.
 ### Community Groups
 Add content.
 
+### Starting a Business Group
+Text. Link to "Creating a Charter".
+
+### Starting a Working Group
+Text. Link to "Creating a Charter".
+
 ### Creating a Charter
 Add content.
 

--- a/mock/chairs/starting_a_group.md
+++ b/mock/chairs/starting_a_group.md
@@ -1,0 +1,23 @@
+# Starting a Group
+## Menu
+* [Is starting a group the right course of action?]() (below)
+* [Incubation and WICG](#) (below)
+* [Community Groups](#) (below)
+* [Creating a Charter](#) (below)
+* [<- Back to **Chairs**](index.md#)
+
+## Content
+Find out whether starting a new group is the right course of action and how to start a group below!
+
+### Is starting a group the right course of action?
+Add content.
+
+### Incubation and WICG
+Add content.
+
+### Community Groups
+Add content.
+
+### Creating a Charter
+Add content.
+

--- a/mock/chairs/starting_a_group.md
+++ b/mock/chairs/starting_a_group.md
@@ -27,3 +27,6 @@ Text. Link to "Creating a Charter".
 ### Creating a Charter
 Add content.
 
+### Amending a Charter
+Add Content.
+

--- a/mock/chairs/starting_a_group.md
+++ b/mock/chairs/starting_a_group.md
@@ -3,7 +3,10 @@
 * [Is starting a group the right course of action?]() (below)
 * [Incubation and WICG](#) (below)
 * [Community Groups](#) (below)
+* [Starting a Business Group](#) (below)
+* [Starting a Working Group](#) (below)
 * [Creating a Charter](#) (below)
+* [Amending a Charter](#) (below)
 * [<- Back to **Chairs**](index.md#)
 
 ## Content

--- a/mock/chairs/tools.md
+++ b/mock/chairs/tools.md
@@ -3,7 +3,8 @@
 * [Mailing List](#) (below)
 * [W3C Wiki](#) (below)
 * [Blog](#) (below)
-* [Group Website](#)
+* [Group Website](#) (below)
+* [<- Back to **Chairs**](index.md#)
 
 ## Content
 Here find all the information on the tools available for running your WG / IG and how to use them

--- a/mock/chairs/tools.md
+++ b/mock/chairs/tools.md
@@ -9,21 +9,20 @@
 ## Content
 Here find all the information on the tools available for running your WG / IG and how to use them
 
-### Sections
-#### Mailing List
+### Mailing List
 Information on mailing lists including how to setup, manage, archives and appropriate behaviour.
 
 W3C maintains a list of all public mailing lists. You can view this [here](https://lists.w3.org/).
 
-#### W3C Wiki
+### W3C Wiki
 W3C wiki location, links to info on how to edit, information on how to manage including Posting Markup examples in W3C wikis).
 
-#### Blog
+### Blog
 Examples of blogs.
 
 If you need a blog, wiki, GitHub repository, or mailing list, ask your team contact.
 
-#### Group Website
+### Group Website
 Setting up a group website, the team members who can help, good examples of group websites. 
 
 

--- a/mock/chairs/tools.md
+++ b/mock/chairs/tools.md
@@ -1,11 +1,11 @@
-# Menu
-* [Mailing List](#)
-* [W3C Wiki](#)
-* [Blog](#)
+# Tools For Running a WG / IG
+## Menu
+* [Mailing List](#) (below)
+* [W3C Wiki](#) (below)
+* [Blog](#) (below)
 * [Group Website](#)
 
-# Content
-## Tools For Running a WG / IG
+## Content
 Here find all the information on the tools available for running your WG / IG and how to use them
 
 ### Sections

--- a/mock/editors/index.md
+++ b/mock/editors/index.md
@@ -2,7 +2,10 @@
 ## Menu
 * [Document Creation and Tools](tools.md)
 * [Rec Track](index.md) (separate section)
+* [Using Github](#) (separate section)
 * [Reviewing Documents](reviewing.md)
+* [List of Mailing Lists](#) (separate section)
+* [<- Back to **Home**](../index.md#)
 
 ## Content
 One of the main accomplishments at W3C is to write specifications and create standards out of them. While the Working Groups at large are responsible for building consensus on the technical decisions, the editors have the heavy responsibility of transforming these decisions into actual specifications.

--- a/mock/editors/index.md
+++ b/mock/editors/index.md
@@ -1,5 +1,5 @@
 # Menu
-* [Document Creation and Tools](#)
+* [Document Creation and Tools](https://github.com/nrooney/Guide/blob/master/mock/editors/tools.md)
 * [Rec Track](#) (separate section)
 * [Reviewing Documents](#)
 

--- a/mock/editors/index.md
+++ b/mock/editors/index.md
@@ -5,5 +5,9 @@
 
 # Content
 ## Information For Editors
-Here find all the information you need on being an Editor for W3C Rec Track Documents and Notes.
+One of the main accomplishments at W3C is to write specifications and create standards out of them. While the Working Groups at large are responsible for building consensus on the technical decisions, the editors have the heavy responsibility of transforming these decisions into actual specifications.
+
+This page tries to gather resources that can help editors do their job: documentation, tools, tutorials, etc. If you know other resources that would benefit editors by being listed here, please inform the W3C Communication Team at w3t-comm@w3.org.
+
+Note: content from <https://www.w3.org/2003/Editors/>
 

--- a/mock/editors/index.md
+++ b/mock/editors/index.md
@@ -1,7 +1,7 @@
 # Menu
 * [Document Creation and Tools](https://github.com/nrooney/Guide/blob/master/mock/editors/tools.md)
-* [Rec Track](#) (separate section)
-* [Reviewing Documents](#)
+* [Rec Track](https://github.com/nrooney/Guide/blob/master/mock/rectrack/index.md) (separate section)
+* [Reviewing Documents](https://github.com/nrooney/Guide/blob/master/mock/editors/reviewing.md)
 
 # Content
 ## Information For Editors

--- a/mock/editors/index.md
+++ b/mock/editors/index.md
@@ -1,10 +1,10 @@
-# Menu
-* [Document Creation and Tools](https://github.com/nrooney/Guide/blob/master/mock/editors/tools.md)
-* [Rec Track](https://github.com/nrooney/Guide/blob/master/mock/rectrack/index.md) (separate section)
-* [Reviewing Documents](https://github.com/nrooney/Guide/blob/master/mock/editors/reviewing.md)
+# Information For Editors
+## Menu
+* [Document Creation and Tools](tools.md)
+* [Rec Track](index.md) (separate section)
+* [Reviewing Documents](reviewing.md)
 
-# Content
-## Information For Editors
+## Content
 One of the main accomplishments at W3C is to write specifications and create standards out of them. While the Working Groups at large are responsible for building consensus on the technical decisions, the editors have the heavy responsibility of transforming these decisions into actual specifications.
 
 This page tries to gather resources that can help editors do their job: documentation, tools, tutorials, etc. If you know other resources that would benefit editors by being listed here, please inform the W3C Communication Team at w3t-comm@w3.org.

--- a/mock/editors/index.md
+++ b/mock/editors/index.md
@@ -1,0 +1,9 @@
+# Menu
+* [Document Creation and Tools](#)
+* [Rec Track](#) (separate section)
+* [Reviewing Documents](#)
+
+# Content
+## Information For Editors
+Here find all the information you need on being an Editor for W3C Rec Track Documents and Notes.
+

--- a/mock/editors/reviewing.md
+++ b/mock/editors/reviewing.md
@@ -1,28 +1,28 @@
-# Menu
-* [Group Reviews](#)
-* [Horizontal Reviews](#)
+# Reviewing Documents
+## Menu
+* [Group Reviews](#) (below)
+* [Horizontal Reviews](#) (below)
+* [<- Back to **Editors**](index.md#)
 
-# Content
-## Reviewing
+## Content
 All W3C [RecTrack](https://github.com/nrooney/Guide/blob/master/mock/rectrack/index.md) Documents need to be reviewed. This page explains the review process, and how to reach out to the groups in charge of the reviewing for particular topics.
 
-### Sections
-#### Group Reviews
+### Group Reviews
 Group reviews occur throughout a RecTrack Document's time on the Recommendations Track. Please see the [RecTrack](https://github.com/nrooney/Guide/blob/master/mock/rectrack/index.md) pages to view when and how to hold RecTrack Reviews.
 
-#### Horizontal Reviews
+### Horizontal Reviews
 Horizontal Reviews are when you request a review of another W3C Group. Below is an explanation of these groups and the reviews they will complete for your document.
 
-#### TAG
+### TAG
 The TAG will do a general review of your document. They will be looking for technical inconsistencies and alignment with other W3C Recommendations as well as making sure the Document fits with the architecture of the web and supported by W3C.
 
 To request TAG review ...
 
-#### Accessibility Review
+### Accessibility Review
 Questionnaire?
 
-#### Privacy Review
+### Privacy Review
 The PING group manage a Privacy Questionnaire. Please reach out to (@todo add mailing list) and request a privacy questionnaire. Please complete this for your document and return it to the PING group.
 
-#### Security Review
+### Security Review
 Questionnaire?

--- a/mock/editors/reviewing.md
+++ b/mock/editors/reviewing.md
@@ -1,12 +1,6 @@
 # Menu
 * [Group Reviews](#)
 * [Horizontal Reviews](#)
-* [](#)
-* [](#)
-* [](#)
-* [](#)
-* [](#)
-* [](#)
 
 # Content
 ## Reviewing

--- a/mock/editors/reviewing.md
+++ b/mock/editors/reviewing.md
@@ -1,0 +1,34 @@
+# Menu
+* [Group Reviews](#)
+* [Horizontal Reviews](#)
+* [](#)
+* [](#)
+* [](#)
+* [](#)
+* [](#)
+* [](#)
+
+# Content
+## Reviewing
+All W3C [RecTrack](https://github.com/nrooney/Guide/blob/master/mock/rectrack/index.md) Documents need to be reviewed. This page explains the review process, and how to reach out to the groups in charge of the reviewing for particular topics.
+
+### Sections
+#### Group Reviews
+Group reviews occur throughout a RecTrack Document's time on the Recommendations Track. Please see the [RecTrack](https://github.com/nrooney/Guide/blob/master/mock/rectrack/index.md) pages to view when and how to hold RecTrack Reviews.
+
+#### Horizontal Reviews
+Horizontal Reviews are when you request a review of another W3C Group. Below is an explanation of these groups and the reviews they will complete for your document.
+
+#### TAG
+The TAG will do a general review of your document. They will be looking for technical inconsistencies and alignment with other W3C Recommendations as well as making sure the Document fits with the architecture of the web and supported by W3C.
+
+To request TAG review ...
+
+#### Accessibility Review
+Questionnaire?
+
+#### Privacy Review
+The PING group manage a Privacy Questionnaire. Please reach out to (@todo add mailing list) and request a privacy questionnaire. Please complete this for your document and return it to the PING group.
+
+#### Security Review
+Questionnaire?

--- a/mock/editors/reviewing.md
+++ b/mock/editors/reviewing.md
@@ -1,11 +1,17 @@
 # Reviewing Documents
 ## Menu
+* [Explainers](#) (below)
 * [Group Reviews](#) (below)
 * [Horizontal Reviews](#) (below)
 * [<- Back to **Editors**](index.md#)
 
 ## Content
 All W3C [RecTrack](https://github.com/nrooney/Guide/blob/master/mock/rectrack/index.md) Documents need to be reviewed. This page explains the review process, and how to reach out to the groups in charge of the reviewing for particular topics.
+
+## Explainers
+"Explainers" as a useful precursor to all forms of review, helping people orient themselves to the problem being solved and the proposed solution approach; useful in general, required for TAG review anyway. Good practice to do it sooner rather than later.
+
+Add Content.
 
 ### Group Reviews
 Group reviews occur throughout a RecTrack Document's time on the Recommendations Track. Please see the [RecTrack](https://github.com/nrooney/Guide/blob/master/mock/rectrack/index.md) pages to view when and how to hold RecTrack Reviews.

--- a/mock/editors/tools.md
+++ b/mock/editors/tools.md
@@ -1,0 +1,25 @@
+# Menu
+* [Style for Group-internal Drafts](#)
+* [ReSpec and BikeShed](#)
+* [Pubrules](#)
+* [Normative References](#)
+
+# Content
+## Document Creation and Tools
+Here find all the information you need on being an Editor for W3C Rec Track Documents and Notes.
+
+@todo: check all tools carried from here: https://www.w3.org/2003/Editors/
+
+#### Style for Group-internal Drafts
+Take and modify content from <https://www.w3.org/2005/03/28-editor-style.html> and <https://w3c.github.io/manual-of-style/>
+
+#### ReSpec and BikeShed
+Take and modify content from <https://tabatkins.github.io/bikeshed/>, <https://github.com/w3c/respec/wiki>
+
+#### Pubrules
+(Publication Requirements) and links to related policies (e.g., namespaces, MIME type registration, version management, and in-place modifications)
+
+Take and modify content from <https://www.w3.org/pubrules/>, <https://www.w3.org/2005/07/13-nsuri>, <https://www.w3.org/2002/06/registering-mediatype2014>, <https://www.w3.org/2005/05/tr-versions>, <https://www.w3.org/2003/01/republishing/>, <https://www.w3.org/Guide/pubrules> and <https://github.com/w3c/specberus/issues>
+
+#### Normative References
+Take and modify content from <https://www.w3.org/2013/09/normative-references>

--- a/mock/editors/tools.md
+++ b/mock/editors/tools.md
@@ -24,6 +24,8 @@ Take and modify content from <https://tabatkins.github.io/bikeshed/>, <https://g
 
 Take and modify content from <https://www.w3.org/pubrules/>, <https://www.w3.org/2005/07/13-nsuri>, <https://www.w3.org/2002/06/registering-mediatype2014>, <https://www.w3.org/2005/05/tr-versions>, <https://www.w3.org/2003/01/republishing/>, <https://www.w3.org/Guide/pubrules> and <https://github.com/w3c/specberus/issues>
 
+Add pubrules checker and other validation tools e.g. html validation, link checker etc.
+
 ### Legacy Tools
 e.g. for xmlspec
 

--- a/mock/editors/tools.md
+++ b/mock/editors/tools.md
@@ -1,25 +1,26 @@
-# Menu
-* [Style for Group-internal Drafts](#)
-* [ReSpec and BikeShed](#)
-* [Pubrules](#)
-* [Normative References](#)
+# Document Creation and Tools
+## Menu
+* [Style for Group-internal Drafts](#) (below)
+* [ReSpec and BikeShed](#) (below)
+* [Pubrules](#) (below)
+* [Normative References](#) (below)
+* [<- Back to **Editors**](index.md#)
 
-# Content
-## Document Creation and Tools
+## Content
 Here find all the information you need on being an Editor for W3C Rec Track Documents and Notes.
 
 @todo: check all tools carried from here: https://www.w3.org/2003/Editors/
 
-#### Style for Group-internal Drafts
+### Style for Group-internal Drafts
 Take and modify content from <https://www.w3.org/2005/03/28-editor-style.html> and <https://w3c.github.io/manual-of-style/>
 
-#### ReSpec and BikeShed
+### ReSpec and BikeShed
 Take and modify content from <https://tabatkins.github.io/bikeshed/>, <https://github.com/w3c/respec/wiki>
 
-#### Pubrules
+### Pubrules
 (Publication Requirements) and links to related policies (e.g., namespaces, MIME type registration, version management, and in-place modifications)
 
 Take and modify content from <https://www.w3.org/pubrules/>, <https://www.w3.org/2005/07/13-nsuri>, <https://www.w3.org/2002/06/registering-mediatype2014>, <https://www.w3.org/2005/05/tr-versions>, <https://www.w3.org/2003/01/republishing/>, <https://www.w3.org/Guide/pubrules> and <https://github.com/w3c/specberus/issues>
 
-#### Normative References
+### Normative References
 Take and modify content from <https://www.w3.org/2013/09/normative-references>

--- a/mock/editors/tools.md
+++ b/mock/editors/tools.md
@@ -25,7 +25,7 @@ Take and modify content from <https://tabatkins.github.io/bikeshed/>, <https://g
 Take and modify content from <https://www.w3.org/pubrules/>, <https://www.w3.org/2005/07/13-nsuri>, <https://www.w3.org/2002/06/registering-mediatype2014>, <https://www.w3.org/2005/05/tr-versions>, <https://www.w3.org/2003/01/republishing/>, <https://www.w3.org/Guide/pubrules> and <https://github.com/w3c/specberus/issues>
 
 ### Legacy Tools
-Add Content.
+e.g. for xmlspec
 
 ### Normative References
 Take and modify content from <https://www.w3.org/2013/09/normative-references>

--- a/mock/editors/tools.md
+++ b/mock/editors/tools.md
@@ -1,9 +1,11 @@
 # Document Creation and Tools
 ## Menu
 * [Style for Group-internal Drafts](#) (below)
+* [Github](#) (separate section)
 * [ReSpec and BikeShed](#) (below)
 * [Pubrules](#) (below)
 * [Normative References](#) (below)
+* [Legacy Tools](#) (below)
 * [<- Back to **Editors**](index.md#)
 
 ## Content
@@ -21,6 +23,9 @@ Take and modify content from <https://tabatkins.github.io/bikeshed/>, <https://g
 (Publication Requirements) and links to related policies (e.g., namespaces, MIME type registration, version management, and in-place modifications)
 
 Take and modify content from <https://www.w3.org/pubrules/>, <https://www.w3.org/2005/07/13-nsuri>, <https://www.w3.org/2002/06/registering-mediatype2014>, <https://www.w3.org/2005/05/tr-versions>, <https://www.w3.org/2003/01/republishing/>, <https://www.w3.org/Guide/pubrules> and <https://github.com/w3c/specberus/issues>
+
+### Legacy Tools
+Add Content.
 
 ### Normative References
 Take and modify content from <https://www.w3.org/2013/09/normative-references>

--- a/mock/index.md
+++ b/mock/index.md
@@ -1,7 +1,7 @@
 # Menu
 * [For Chairs](https://github.com/nrooney/Guide/blob/master/mock/chairs/index.md)
 * [For Editors](https://github.com/nrooney/Guide/blob/master/mock/editors/index.md)
-* [For Members and Group Participants](#)
+* [For Members and Group Participants](https://github.com/nrooney/Guide/blob/master/mock/participants/index.md)
 * [Staff Portal](#)
 
 #### Generic Info

--- a/mock/index.md
+++ b/mock/index.md
@@ -4,7 +4,7 @@
 * [For Members and Group Participants](#)
 * [Meetings and IRC](#)
 * [W3C Groups](#)
-* [Rec Track](#)
+* [Rec Track](https://github.com/nrooney/Guide/blob/master/mock/rectrack/index.md)
 * [Github](#)
 * [Events](#)
 * [Legal](#)

--- a/mock/index.md
+++ b/mock/index.md
@@ -2,6 +2,8 @@
 * [For Chairs](https://github.com/nrooney/Guide/blob/master/mock/chairs/index.md)
 * [For Editors](https://github.com/nrooney/Guide/blob/master/mock/editors/index.md)
 * [For Members and Group Participants](#)
+* [Staff Portal](#)
+
 * [Meetings and IRC](#)
 * [W3C Groups](#)
 * [Rec Track](https://github.com/nrooney/Guide/blob/master/mock/rectrack/index.md)
@@ -9,7 +11,6 @@
 * [Events](#)
 * [Legal](#)
 * [Code of Conduct](#)
-* [Staff Portal](#)
 
 # Content
 ## Welcome

--- a/mock/index.md
+++ b/mock/index.md
@@ -1,10 +1,11 @@
-# Menu
+# /Guide Homepage
+## Menu
 * [For Chairs](https://github.com/nrooney/Guide/blob/master/mock/chairs/index.md)
 * [For Editors](https://github.com/nrooney/Guide/blob/master/mock/editors/index.md)
 * [For Members and Group Participants](https://github.com/nrooney/Guide/blob/master/mock/participants/index.md)
 * [Staff Portal](#)
 
-#### Generic Info
+### Generic Info
 * [Meetings and IRC](#)
 * [W3C Groups](#)
 * [Rec Track](https://github.com/nrooney/Guide/blob/master/mock/rectrack/index.md)
@@ -13,11 +14,11 @@
 * [Legal](#)
 * [Code of Conduct](#)
 
-# Content
-## Welcome
+## Content
+### Welcome
 Welcome to the W3C Guide! Here you'll find information on how to participate in W3C. Have a suggestion on how this guide can improve? Please [raise an issue](#) in our github repo!
 
-## Hot Links
+### Hot Links
 * [Using IRC & Scribing](#)
 * [TPAC / AC](#)
 * [Meeting Calendar & Teleconf Details](#)

--- a/mock/index.md
+++ b/mock/index.md
@@ -3,7 +3,6 @@
 * [For Editors](https://github.com/nrooney/Guide/blob/master/mock/editors/index.md)
 * [For Members and Group Participants](#)
 * [Staff Portal](#)
-
 * [Meetings and IRC](#)
 * [W3C Groups](#)
 * [Rec Track](https://github.com/nrooney/Guide/blob/master/mock/rectrack/index.md)

--- a/mock/index.md
+++ b/mock/index.md
@@ -3,6 +3,8 @@
 * [For Editors](https://github.com/nrooney/Guide/blob/master/mock/editors/index.md)
 * [For Members and Group Participants](#)
 * [Staff Portal](#)
+
+#### Generic Info
 * [Meetings and IRC](#)
 * [W3C Groups](#)
 * [Rec Track](https://github.com/nrooney/Guide/blob/master/mock/rectrack/index.md)

--- a/mock/index.md
+++ b/mock/index.md
@@ -1,6 +1,6 @@
 # Menu
 * [For Chairs](https://github.com/nrooney/Guide/blob/master/mock/chairs/index.md)
-* [For Editors](#)
+* [For Editors](https://github.com/nrooney/Guide/blob/master/mock/editors/index.md)
 * [For Members and Group Participants](#)
 * [Meetings and IRC](#)
 * [W3C Groups](#)

--- a/mock/participants/index.md
+++ b/mock/participants/index.md
@@ -7,7 +7,7 @@
 * [Using IRC & Scribing](#) (separate section)
 * [Mailing Lists](mailing_lists.md)
 * [Using W3C Wiki](#) (separate section)
-* [<- Back to **Home**](index.md#)
+* [<- Back to **Home**](../index.md#)
 
 ## Content
 ### Join a group 

--- a/mock/participants/index.md
+++ b/mock/participants/index.md
@@ -1,20 +1,17 @@
 # Informations for Members and Participants
 ## Menu
 * [Join a group](#) (below)
-* [Invited Experts](#)
-* [Attending Teleconferences](#)
+* [Invited Experts](invited_experts.md)
+* [Attending Teleconferences](teleconfs.md)
 * [Using Github](#) (separate section)
 * [Using IRC & Scribing](#) (separate section)
-* [Mailing Lists](#)
+* [Mailing Lists](mailing_lists.md)
 * [Using W3C Wiki](#) (separate section)
 * [<- Back to **Home**](index.md#)
 
 ## Content
 ### Join a group 
 AC member to add to group, see also Invited Expert Policy
-
-### Invited Experts
-Becoming an invited expert, invited expert mailing list.
 
 ### Attending Teleconferences
 Webex, link to IRC guide.
@@ -24,9 +21,6 @@ Separate Section. Link direct to Github guide.
 
 ### Using IRC & Scribing
 Separate Section. Link direct to IRC guide.
-
-### Mailing Lists
-Discovering the mailing lists. Decorum, top posting, good mail clients, archive.
 
 ### Using W3C Wiki
 [Chairs section](../chairs/tools.md#) also has this - split out into own section?

--- a/mock/participants/index.md
+++ b/mock/participants/index.md
@@ -4,6 +4,7 @@
 * [Invited Experts](invited_experts.md)
 * [Attending Teleconferences](teleconfs.md)
 * [Using Github](#) (separate section)
+* [Making Contribution](#) (needs page)
 * [Using IRC & Scribing](#) (separate section)
 * [Mailing Lists](mailing_lists.md)
 * [Using W3C Wiki](#) (separate section)

--- a/mock/participants/index.md
+++ b/mock/participants/index.md
@@ -1,33 +1,32 @@
-# Menu
-* [Join a group](#)
+# Informations for Members and Participants
+## Menu
+* [Join a group](#) (below)
 * [Invited Experts](#)
 * [Attending Teleconferences](#)
-* [Using Github (own section)](#)
-* [Using IRC & Scribing (own section)](#)
+* [Using Github](#) (separate section)
+* [Using IRC & Scribing](#) (separate section)
 * [Mailing Lists](#)
-* [Using W3C Wiki (own section)](#)
+* [Using W3C Wiki](#) (separate section)
+* [<- Back to **Home**](index.md#)
 
-# Content
-## Informations for Members and Participants
-
-### Sections
-#### Join a group 
+## Content
+### Join a group 
 AC member to add to group, see also Invited Expert Policy
 
-#### Invited Experts
+### Invited Experts
 Becoming an invited expert, invited expert mailing list.
 
-#### Attending Teleconferences
+### Attending Teleconferences
 Webex, link to IRC guide.
 
-#### Using Github
+### Using Github
 Separate Section. Link direct to Github guide.
 
-#### Using IRC & Scribing
+### Using IRC & Scribing
 Separate Section. Link direct to IRC guide.
 
-#### Mailing Lists
+### Mailing Lists
 Discovering the mailing lists. Decorum, top posting, good mail clients, archive.
 
-#### Using W3C Wiki
-[Chairs section](https://github.com/nrooney/Guide/blob/master/mock/chairs/tools.md#) also has this - split out into own section?
+### Using W3C Wiki
+[Chairs section](../chairs/tools.md#) also has this - split out into own section?

--- a/mock/participants/index.md
+++ b/mock/participants/index.md
@@ -1,0 +1,33 @@
+# Menu
+* [Join a group](#)
+* [Invited Experts](#)
+* [Attending Teleconferences](#)
+* [Using Github (own section)](#)
+* [Using IRC & Scribing (own section)](#)
+* [Mailing Lists](#)
+* [Using W3C Wiki (own section)](#)
+
+# Content
+## Informations for Members and Participants
+
+### Sections
+#### Join a group 
+AC member to add to group, see also Invited Expert Policy
+
+#### Invited Experts
+Becoming an invited expert, invited expert mailing list.
+
+#### Attending Teleconferences
+Webex, link to IRC guide.
+
+#### Using Github
+Separate Section. Link direct to Github guide.
+
+#### Using IRC & Scribing
+Separate Section. Link direct to IRC guide.
+
+#### Mailing Lists
+Discovering the mailing lists. Decorum, top posting, good mail clients, archive.
+
+#### Using W3C Wiki
+[Chairs section](https://github.com/nrooney/Guide/blob/master/mock/chairs/tools.md#) also has this - split out into own section?

--- a/mock/participants/invited_experts.md
+++ b/mock/participants/invited_experts.md
@@ -7,3 +7,9 @@
 Invited Experts to W3C can find information below to aid in their participation at W3C.
 
 @todo Florian could add content here (or pass to a contact)
+
+### Becoming an Invited Expert
+Text on how to become an invited expert.
+
+### Subtitle
+Mailing list details.

--- a/mock/participants/invited_experts.md
+++ b/mock/participants/invited_experts.md
@@ -1,0 +1,9 @@
+# Invited Experts
+## Menu
+* [Mailing List](#) (below)
+* [<- Back to **Members and Participants**](index.md)
+
+## Content
+Invited Experts to W3C can find information below to aid in their participation at W3C.
+
+@todo Florian could add content here (or pass to a contact)

--- a/mock/participants/mailing_lists.md
+++ b/mock/participants/mailing_lists.md
@@ -1,0 +1,32 @@
+# Mailing Lists
+## Menu
+* [Finding your group Mailing List](#) (below)
+* [How to Reply and "Top Posting"](#) (below)
+* [Github and Mailing Lists](#) (below)
+* [Plugins for Outlook and other Mail Clients](#) (below)
+* [Advice on Conduct on Mailing Lists](#) (below)
+* [Complaints and Issues](#) (below)
+* [<- Back to **Members and Participants**](index.md)
+
+## Content
+Mailing lists are used by W3C groups to discuss work, organise meetings and drive deliverables forward. Learn how mailing lists work and conduct guidelines below.
+
+### Finding your group Mailing List
+To find your group mailing list visit the group homepage...
+
+### How to Reply and "Top Posting"
+W3C participants often
+
+### Github and Mailing Lists
+Many groups use Github to manage their documentation and deliverables. Github may send automated emails to the group mailing list. To respond to these...
+
+To remove yourself from the Github mails...
+
+### Plugins for Outlook and other Mail Clients
+Outlook and some other mail clients do not format reply emails well and make it difficult for participants to reply or follow inline-replied emails. Plugins can help...
+
+### Advice on Conduct on Mailing Lists
+Add content.
+
+### Complaints and Issues
+If you have any issues or complaints ...

--- a/mock/participants/mailing_lists.md
+++ b/mock/participants/mailing_lists.md
@@ -1,18 +1,24 @@
 # Mailing Lists
 ## Menu
 * [Finding your group Mailing List](#) (below)
+* [Mailing List Archives](#) (below)
 * [How to Reply and "Top Posting"](#) (below)
 * [Github and Mailing Lists](#) (below)
 * [Plugins for Outlook and other Mail Clients](#) (below)
-* [Advice on Conduct on Mailing Lists](#) (below)
+* [Advice on Decorum on Mailing Lists](#) (below)
 * [Complaints and Issues](#) (below)
 * [<- Back to **Members and Participants**](index.md)
 
 ## Content
-Mailing lists are used by W3C groups to discuss work, organise meetings and drive deliverables forward. Learn how mailing lists work and conduct guidelines below.
+Mailing lists are used by W3C groups to discuss work, organise meetings and drive deliverables forward. Learn how mailing lists work and decorum guidelines below.
 
 ### Finding your group Mailing List
 To find your group mailing list visit the group homepage...
+
+To find all group mailing lists...
+
+### Mailing List Archives
+All W3C groups have a mailing list archive which will hold all mails sent on the list...
 
 ### How to Reply and "Top Posting"
 W3C participants often
@@ -25,7 +31,7 @@ To remove yourself from the Github mails...
 ### Plugins for Outlook and other Mail Clients
 Outlook and some other mail clients do not format reply emails well and make it difficult for participants to reply or follow inline-replied emails. Plugins can help...
 
-### Advice on Conduct on Mailing Lists
+### Advice on Decorum on Mailing Lists
 Add content.
 
 ### Complaints and Issues

--- a/mock/participants/teleconfs.md
+++ b/mock/participants/teleconfs.md
@@ -1,0 +1,23 @@
+# Teleconferences
+## Menu
+* [Webex and Other Services](#) (below)
+* [](#) (below)
+* [](#) (link to another section of /guide)
+* [<- Back to **Members and Participants**](index.md)
+
+## Content
+Find information on attending group teleconferences below.
+
+### Webex and Other Services
+The W3C system for teleconferences is Webex. Prior to a teleconference meeting group members should receive Webex details from the chair or team contact. Webex can be joined via the web, via the Webex app or via the phone. Webex has dial in numbers for many countries around the world, see [here](#) for a list of the dial-in numbers.
+
+#### Other Systems
+Sometimes a group will opt to use another teleconference system. This may be because the chair has use of a system at their workplace which they prefer to use. W3C allows this, but if any group members have as issue with this please let the chair or team contact know so they can encourage the chair to move to the Webex system. 
+
+### IRC
+@todo Add content and link to main IRC Page. Ask Nigel if there's a good IRC guide that he's seen targetted to participants.
+
+### Speaking and Adding Items to an Agenda
+To speak in a W3C teleconference add yourself to the queue by typing "q+" in IRC. The chair will see that you have been added to the speaking queue, and when it is your turn to speak the chair will call on you to speak.
+
+If you wish to have an item added to the agenda please email your group mailing list previously, or let yuor chair know at the beginning of the meeting. Different chairs run meetings in different ways, so chairs may encourage you to take your item to the mailing list or wait till a later meeting. If you have any issues with these decisions feel free to speak to your team contact.

--- a/mock/participants/teleconfs.md
+++ b/mock/participants/teleconfs.md
@@ -1,8 +1,9 @@
 # Teleconferences
 ## Menu
 * [Webex and Other Services](#) (below)
-* [](#) (below)
-* [](#) (link to another section of /guide)
+* [IRC](#irc) (below)
+* [Speaking and Adding Items to an Agenda](#irc) (below)
+* [Calendar Invites](#calendar-invites) (below)
 * [<- Back to **Members and Participants**](index.md)
 
 ## Content
@@ -21,3 +22,6 @@ Sometimes a group will opt to use another teleconference system. This may be bec
 To speak in a W3C teleconference add yourself to the queue by typing "q+" in IRC. The chair will see that you have been added to the speaking queue, and when it is your turn to speak the chair will call on you to speak.
 
 If you wish to have an item added to the agenda please email your group mailing list previously, or let yuor chair know at the beginning of the meeting. Different chairs run meetings in different ways, so chairs may encourage you to take your item to the mailing list or wait till a later meeting. If you have any issues with these decisions feel free to speak to your team contact.
+
+### Calendar Invites
+Calendar invites are rarely sent for W3C meetings. It is up to the participant to add the invite using their calendar tool when they receive an email from their chair / team contact regarding the next group meeting. If you have issues with the process please email your group team contact.

--- a/mock/rectrack/index.md
+++ b/mock/rectrack/index.md
@@ -1,9 +1,15 @@
-# Menu
-* [Recommendation Track Readiness Best Practices](#)
+# Recommendations Track
+## Menu
+* [Rec Track Explained](#) (below)
+* [Recommendation Track Readiness Best Practices](#) (below)
 
-# Content
-## Recommendations Track
+## Content
 This page gives an understanding of the W3C "RecTrack" or Recommendations Track.
 
+### Rec Track Explained
 Take and modify content from <https://github.com/w3c/wg-effectiveness/blob/master/process.md#w3c-recommenation-technical-report-flow-the-recommendation-track>
+
+### Recommendation Track Readiness Best Practices
+Take and modify content from <XXXXXXX>
+
 

--- a/mock/rectrack/index.md
+++ b/mock/rectrack/index.md
@@ -2,6 +2,7 @@
 ## Menu
 * [Rec Track Explained](#) (below)
 * [Recommendation Track Readiness Best Practices](#) (below)
+* [<- Back to **Home**](home.md#)
 
 ## Content
 This page gives an understanding of the W3C "RecTrack" or Recommendations Track.

--- a/mock/rectrack/index.md
+++ b/mock/rectrack/index.md
@@ -11,6 +11,8 @@ This page gives an understanding of the W3C "RecTrack" or Recommendations Track.
 Take and modify content from <https://github.com/w3c/wg-effectiveness/blob/master/process.md#w3c-recommenation-technical-report-flow-the-recommendation-track>
 
 ### Recommendation Track Readiness Best Practices
-Take and modify content from <XXXXXXX>
+Add Content.
+
+Include best practice advice to accompany all proposals for normative changes with tests that can be contributed to test suites, since they will be needed to exit CR anyway, and they help clarify exactly what the spec text needs to say.
 
 

--- a/mock/rectrack/index.md
+++ b/mock/rectrack/index.md
@@ -1,0 +1,9 @@
+# Menu
+* [Recommendation Track Readiness Best Practices](#)
+
+# Content
+## Recommendations Track
+This page gives an understanding of the W3C "RecTrack" or Recommendations Track.
+
+Take and modify content from <https://github.com/w3c/wg-effectiveness/blob/master/process.md#w3c-recommenation-technical-report-flow-the-recommendation-track>
+

--- a/mock/rectrack/index.md
+++ b/mock/rectrack/index.md
@@ -2,7 +2,7 @@
 ## Menu
 * [Rec Track Explained](#) (below)
 * [Recommendation Track Readiness Best Practices](#) (below)
-* [<- Back to **Home**](home.md#)
+* [<- Back to **Home**](../index.md)
 
 ## Content
 This page gives an understanding of the W3C "RecTrack" or Recommendations Track.


### PR DESCRIPTION
A mock information architecture in which we can start adding in content and further links for the copy sections of /guide.

Kaz and Plh may be able to explain if you need more info!