### PR TITLE
consolidate links re: horizontal/wide review

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,19 +180,6 @@
         </li>
         <li><a id="predicting" href="process/predicting-milestones.html">Predicting
             milestones</a>, use our <a href='https://w3c.github.io/spec-releases/milestones/'>milestones calculator</a> to help with dates.</li>
-        <li id="horizontal-review">Horizontal reviews
-          <ul>
-            <li>Internationalization: <a href="https://www.w3.org/International/about#contact">Contact
-                the WG</a> • <a href="https://www.w3.org/International/review-request">Request
-                a review</a> • <a href="https://github.com/w3c/i18n-activity/projects/1">Review
-                radar</a> • <a href="https://w3c.github.io/i18n-activity/reviews/">Review
-                comment tracker</a></li>
-	    <li>Security and Privacy: <a href="https://www.w3.org/TR/security-privacy-questionnaire/">self-review questionnaire</a></li>
-            <li>Remember to request a review <em>2-3 months before CR</em>, to
-              allow time for discussion and rework.</li>
-            <li><a href="https://www.w3.org/wiki/DocumentReview#Horizontal_Groups">Groups with a horizontal review function</a></li>
-          </ul>
-        </li>
         <li>Face-to-face meetings
           <ul>
             <li>Send face-to-face meeting information to calreq@w3.org; that
@@ -243,8 +230,8 @@
                 Reports</a> of the W3C Process</li>
             <li><a href="https://www.w3.org/Guide/transitions">Transition requirements</a> for all W3C
               maturity levels (First Public Draft, Last Call, CR, PR, REC, etc.). Try also our <a href="https://w3c.github.io/transitions/nextstep.html">step finder</a> and look at <a href="https://w3c.github.io/spec-releases/milestones/">milestones calculator</a>.</li>
-            <li>Get <a href="https://www.w3.org/wiki/DocumentReview">Wide
-                Review</a>,</li>
+            <li>Request <a href="https://www.w3.org/wiki/DocumentReview">Wide
+                Review</a> at least <em>2-3 months before CR</em>, to allow time for discussion and rework.</li>
             <li><a href="https://www.w3.org/pubrules/">Pubrules</a> (<a href="https://www.w3.org/pubrules/doc">publication
                 requirements</a>) and links to related policies (e.g., <a href="https://www.w3.org/2005/07/13-nsuri">namespaces</a>,
               <a href="https://www.w3.org/2002/06/registering-mediatype2014">MIME type
@@ -390,8 +377,6 @@
         <li><a href="https://w3c.github.io/manual-of-style/">W3C Manual of Style</a></li>
         <li><a href="https://www.w3.org/2002/05/rec-tips">Tips for getting to Recommendation
             faster</a></li>
-        <li>A <a href="https://www.w3.org/2014/11/getreview/">Template to
-            create requests for Specification Review</a>.</li>
       </ul>
       <h4 id="GitHub">GitHub</h4>
       <ul>


### PR DESCRIPTION
 Remove redundancy by consolidating links to groups and resources on the review wiki page.  consolidate links to that wiki page to a single link here.