### PR TITLE
Trim the news

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,11 +37,7 @@
       <h4 id="training">Chair Training Modules</h4>
       <ul>
         <li>none upcoming at this time</li>
-        <!--
-        <li>New W3C Recommendation Track, Steve Zilles (TBC)</li>
-        <li> Making rapid progress in developing specs in W3C despite the W3C
-          process (TBC)</li>
--->
+
         <li>Previous:
           <ul>
             <li><a href="https://www.w3.org/2015/Talks/1217-github-w3c/">Using
@@ -106,29 +102,16 @@
         <li>2019-03-07: <a href="https://lists.w3.org/Archives/Member/chairs/2019JanMar/0133.html">retirement of dev.w3.org CVS service</a></li>
         <li>2019-03-06: <a href="https://lists.w3.org/Archives/Member/chairs/2019JanMar/0130.html">Feedback on Horizontal Review</a></li>
         <li>2019-03-01: <a href="https://lists.w3.org/Archives/Member/chairs/2019JanMar/0128.html">W3C's public bugzilla to be shut down</a></li>
-        <li>2019-02-28: <a href="https://lists.w3.org/Archives/Member/chairs/2019JanMar/0127.html">Daylight Saving Time (DST) change -- first half of 2019</a></li>
         <li>2019-02-26: <a href="https://lists.w3.org/Archives/Member/chairs/2019JanMar/0122.html">W3C Mercurial service (dvcs.w3.org) to be retired on 1 April 2019</a></li>
         <li>2019-02-15: <a href="https://lists.w3.org/Archives/Member/chairs/2019JanMar/0039.html">2019 Process Document Operational on 1 March 2019</a></li>
-        <li>2019-02-13: <a href="https://lists.w3.org/Archives/Member/chairs/2019JanMar/0034.html">lightning talks for AC meeting</a></li>
-        <li>2019-01-22: <a href="https://lists.w3.org/Archives/Member/chairs/2019JanMar/0011.html">Québec City AC Meeting 2019 Registration Now Open</a></li>
-        <li>2019-01-17: <a href="https://lists.w3.org/Archives/Member/chairs/2019JanMar/0008.html">Publishing moratorium for first half of 2019</a></li>
         <li>2018-12-11: <a href="https://lists.w3.org/Archives/Member/chairs/2018OctDec/0078.html">About RawGit, and possible replacements</a></li>
         <li>2018-08-16: <a href="https://lists.w3.org/Archives/Member/chairs/2018JulSep/0101.html">W3C Chair Buddy System</a></li>
         <li>2018-07-02: <a href="https://github.com/w3c/echidna/wiki/CR-publication-workflow">Echidna now supports Candidate Recommendations</a></li>
         <li>2018-01-17: <a href="https://lists.w3.org/Archives/Member/chairs/2018JanMar/0012.html">Three things I wish I knew before becoming a chair</a></li>
         <li>2017-12-13: <a href="https://lists.w3.org/Archives/Member/chairs/2017OctDec/0189.html">"Processing of Formal Objections" document enacted, now in effect</a></li>
-        <li>2017-11-07: <a href="https://lists.w3.org/Archives/Member/chairs/2017OctDec/0129.html">Working Group Effectiveness Task Force</a></li>
-      <li>2017-08-01: <a href="https://lists.w3.org/Archives/Member/chairs/2017JulSep/0048.html">Please keep all WebEx meeting coordinates out of public view</a></li>
-      <li>2017-06-16: <a href="https://lists.w3.org/Archives/Member/chairs/2017AprJun/0136.html">W3C
-            Blog: Please, seek MarComm review and coordination</a></li>
-        <li>2017-06-12: <a href="https://lists.w3.org/Archives/Member/chairs/2017AprJun/0123.html">Transition
-            requirements update</a></li>
-        <li>2017-05-23: <a href="https://lists.w3.org/Archives/Member/chairs/2017AprJun/0085.html">How
-            to engage with the i18n WG for assistance and reviews</a></li>
-        <li>2017-03-15: <a href="https://lists.w3.org/Archives/Member/chairs/2017JanMar/0141.html">W3C
-            Travel Policy affecting Staff Contacts</a></li>
       </ul>
-      <h3 id="start" style="margin-top: 2em">Starting a Group</h3>
+
+	    <h3 id="start" style="margin-top: 2em">Starting a Group</h3>
       <ul>
         <li><a href="https://www.w3.org/Guide/standards-track/">Recommendation Track Readiness Best
             Practices</a></li>
@@ -148,6 +131,7 @@
           your team contact.</li>
         <li>...more <a href="#roles">advice on roles in a group</a></li>
       </ul>
+	    
       <h3 id="run">Running a Group</h3>
       <ul>
         <li><a href="https://www.w3.org/Guide/chair/buddy.html">W3C Chair Buddy System</a> (volunteer experienced Chairs can mentor other Chairs)</li>
@@ -189,6 +173,8 @@
 	      and <a href="https://www.w3.org/2011/06/WorkshopHost.html">Standard Venue Arrangements for W3C Events: Conferences, Workshops, and Meetings</a></li>
             <li><a href="https://www.w3.org/2004/06/NoNDAPolicy.html">Policy Regarding
                 Non-Disclosure Agreements and W3C Meetings</a></li>
+            <li><a href="https://lists.w3.org/Archives/Member/chairs/2017JanMar/0141.html">W3C
+            Travel Policy affecting Staff Contacts</a></li>
           </ul>
         </li>
         <li>Issue tracking:
@@ -218,6 +204,7 @@
         <li>...more <a href="#mtg-advice">advice on meetings, decisions, issue
             tracking</a></li>
       </ul>
+	    
       <h3 id="Deliverables">Specification Development</h3>
       <ul>
         <li><a href="https://www.w3.org/2003/Editors/">W3C Editors home page</a> and specifically
@@ -231,7 +218,8 @@
             <li><a href="https://www.w3.org/Guide/transitions">Transition requirements</a> for all W3C
               maturity levels (First Public Draft, Last Call, CR, PR, REC, etc.). Try also our <a href="https://w3c.github.io/transitions/nextstep.html">step finder</a> and look at <a href="https://w3c.github.io/spec-releases/milestones/">milestones calculator</a>.</li>
             <li>Request <a href="https://www.w3.org/wiki/DocumentReview">Wide
-                Review</a> at least <em>2-3 months before CR</em>, to allow time for discussion and rework.</li>
+                Review</a> at least <em>2-3 months before CR</em>, to allow time for discussion and rework. See also 
+		<a href="https://lists.w3.org/Archives/Member/chairs/2017AprJun/0085.html">How to engage with the i18n WG for assistance and reviews</a></li>
             <li><a href="https://www.w3.org/pubrules/">Pubrules</a> (<a href="https://www.w3.org/pubrules/doc">publication
                 requirements</a>) and links to related policies (e.g., <a href="https://www.w3.org/2005/07/13-nsuri">namespaces</a>,
               <a href="https://www.w3.org/2020/01/registering-mediatypes">MIME type


### PR DESCRIPTION
Move things that have been news for a few years into the relevant section of the Guide itself.

Plus a little whitespace tweaking to make the source easier to navigate