### PR TITLE
Move the section on meeting formats to the end

### DIFF
--- a/meetings/continuity.html
+++ b/meetings/continuity.html
@@ -70,6 +70,7 @@
             <li>set an alternative dynamic compared to interactions by email/Github or during teleconferences</li>
             <li>Focus on a set of issues and goals instead of being distracted;</li>
             <li>Bring to closure hard issues that have been languishing for months due to lack of consensus.</li>
+      </ol>
       </p>
 
       <dl>
@@ -91,44 +92,14 @@
             <li>Steering Committee meetings;</li>
             <li>Advisory Committee meetings.</li>
       </ol>
+
+      <p>Virtual presence meetings can take several forms; refer to
+        the section <a href="#sessions">Meeting Formats</a>
+        below for examples.</p>
+
       <p class='note'>
 		Note: <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2020JanMar/0025.html">AC 2020</a> (member link) will be a distributed meeting and <a href='https://lists.w3.org/Archives/Member/w3c-ac-members/2019JulSep/0036.html'>TPAC 2020</a> (member link) is, as of 13 March 2020, happening as planned,
             on 26-30 October 2020, in Vancouver BC, Canada.
-      </p>
-
-      <h3 id='sessions'>Virtual presence meetings</h3>
-      <p>
-            Agenda items during virtual presence meetings could take several following forms. The list below proposes different methods
-            of replacement in lieu of in-person meetings.
-      </p>
-      <dl>
-            <dt>Discussion-only sessions</dt>
-            <dd>
-                  <p>Intended for agenda items requiring only discussions (such as specification issues or panels).
-                  Those should be replaced by dedicated discussion with virtual presence, possibly clustered.
-                  </p>
-            </dd>
-            <dt>Presentation+discussion sessions</dt>
-            <dd>
-                  <p>Intended for agenda items requiring a presentation first, followed by a discussion (such
-                        as technical proposals or position papers).
-                  Those <em>should</em> be replaced by pre-recording the presentation(s) with slides at least 24 hours
-                  before the discussion (to avoid burden on non-timezone friendly participants).
-                  Then, the participants can have one or more dedicated discussion with virtual presence.</p>
-            </dd>
-            <dt>Update sessions</dt>
-            <dd>
-                  <p>Intended for agenda items to update the participants on specific items (such as implementation reports or
-                        editor updates).
-                  Those <strong>should</strong> be replaced by pre-recording the presentation(s) with slides, with possibly <em>one</em>
-                  teleconference to allow for questions, clustering the updates together. You <em>MAY</em> however
-                  differ those sessions depending on the important of the topic.</p>
-                  </p>
-            </dd>
-      </dl>
-      <p>
-            For all types of sessions, the Chairs should also allow asynchronous feedback and discussions,
-            using GitHub issues, emails, or other forms of input before and after a virtual presence meeting, or between days in the case of a multi-day meeting.
       </p>
 
       <h2 id='virtualPresence'>Arrangements for Virtual Presence</h2>
@@ -260,6 +231,52 @@
             of the Advisory Committee meeting. Recordings <em>may</em> be available for a limited time for
             special guests.
       </p>
+
+      <h2 id='sessions'>Meeting Formats</h2>
+      <p>
+            Agenda items during virtual presence meetings could take
+            several of the following forms. The following sections
+            propose different forms of replacement in lieu of
+            in-person meetings.
+      </p>
+      <p>
+        For all forms of sessions the Chairs should also allow
+        asynchronous feedback and discussions, using GitHub issues,
+        emails, or other forms of input before and after a virtual
+        presence meeting, or between days in the case of a multi-day
+        meeting.
+      </p>
+
+	<h3 id='discussionSessions'>Primarily Discussion Sessions</h3>
+	<p>Intended for agenda items requiring only discussions (such
+           as specification issues or panels).  Those should be
+           replaced by dedicated discussion with virtual presence,
+           possibly clustered.
+        </p>
+
+	<h3 id='presentationSessions'>Presentation+Discussion Sessions</h3>
+
+	<p>Intended for agenda items requiring a presentation first,
+           followed by a discussion (such as technical proposals or
+           position papers).  Those <em>should</em> be replaced by
+           pre-recording the presentation(s) with slides at least 24
+           hours before the discussion (to avoid burden on
+           non-timezone friendly participants).  Then, the
+           participants can have one or more dedicated discussion with
+           virtual presence.
+	</p>
+
+        <h3 id='updateSessions'>Update Sessions</h3>
+        <p>Intended for agenda items to update the participants on
+           specific items (such as implementation reports or editor
+           updates).  Those <strong>should</strong> be replaced by
+           pre-recording the presentation(s) with slides, with
+           possibly <em>one</em> teleconference to allow for
+           questions, clustering the updates
+           together. You <em>MAY</em> however differ those sessions
+           depending on the important of the topic.
+	</p>
+      </dl>
 
       <hr>
       <address><a href="mailto:plh@w3.org">plh</a>, <a href="mailto:swick@w3.org">Ralph</a></address>


### PR DESCRIPTION
The material on how to arrange for virtual presence is more critical than the taxonomy of session types.

Addresses #68