### PR TITLE
Tweaks to help non-W3C groups

### DIFF
--- a/meetings/continuity.html
+++ b/meetings/continuity.html
@@ -72,14 +72,14 @@
       <p>The W3C <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a> applies to
             all W3C meetings, no matter their format.</p>
 
-      <h2 id='policy'>General policy for W3C meetings</h2>
+      <h2 id='policy'>General policy for meetings</h2>
 
       <p>
-            Meeting face-to-face is an important component of the work for some of our Groups. It enables Group chairs to:
+            Meeting face-to-face is an important component of the work for some of our Groups. Meetings enable Group chairs to:
       </p>
       <ol>
             <li>set an alternative dynamic compared to interactions by email/Github or during teleconferences</li>
-            <li>Focus on a set of issues and goals instead of being distracted;</li>
+            <li>Focus synchronously on a set of issues and goals and reduce distractions;</li>
             <li>Bring to closure hard issues that have been languishing for months due to lack of consensus.</li>
       </ol>
       </p>
@@ -90,7 +90,7 @@
             needs.</dd>
       </dl>
 
-      <h2 id='types'>Different meetings</h2>
+      <h2 id='types'>Meeting Purposes</h2>
 
       <p>
             We encounter several types of in-person meetings at W3C:
@@ -103,15 +103,16 @@
             <li>Advisory Committee meetings.</li>
       </ol>
 
-      <p>Virtual presence meetings can take several forms; refer to
+      <p>Virtual presence meetings can take several forms, some better suited
+	to the meeting purpose than others. Refer to
         the section <a href="#sessions">Meeting Formats</a>
         below for examples.</p>
 
       <p class='note'>
 	Note:
 	<ul>
-	  <li><a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2020JanMar/0025.html">AC 2020</a> (member link) will be a distributed meeting</li>
-	  <li><a href='https://lists.w3.org/Archives/Member/w3c-ac-members/2019JulSep/0036.html'>TPAC 2020</a> (member link) is, as of 13 March 2020, happening as planned,
+	  <li><a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2020JanMar/0025.html">W3C May 2020 Advisory Committee Meeting</a> (member link) will be a distributed meeting</li>
+	  <li><a href='https://lists.w3.org/Archives/Member/w3c-ac-members/2019JulSep/0036.html'>W3C 2020 TPAC</a> (member link) is, as of 13 March 2020, happening as planned,
             on 26-30 October 2020, in Vancouver BC, Canada. We are however working a virtual backup.</li>
 	</ul>
       </p>

--- a/meetings/continuity.html
+++ b/meetings/continuity.html
@@ -209,7 +209,7 @@
             <li>internationalization</li>
             <li>interoperable browser support</li>
             <li>network bandwidth</li>
-            <li>Native platform independence (a native app that works on Linux, Mac, Windows…)</li>
+            <li>Native platform independence (a native app that works on Linux, Mac, Windows, …)</li>
             <li>privacy</li>
             <li>queue management</li>
             <li>reliability</li>
@@ -235,7 +235,7 @@
 	Workshops are often key gathering spots for consideration of new ideas,
         with a mix of prepared presentation, pre-determined or self-organizing breakout sessions,
         and the all-important "hallway track" opportunity for side conversations.
-	Organizers are enouraged to replicate this mix in virtual meetings. Some proposals include:
+	Organizers are encouraged to replicate this mix in virtual meetings. Some proposals include:
 	<ul>
             <li>Plenary-style presentations: one or a few people present to the group and take questions.
 	      <li>Distributed breakouts: break into parallel channels with distinct videoconference lines (or zoom's "breakout" feature) and report back.


### PR DESCRIPTION
Like W3C's Code of Conduct, this document might be of interest to others outside of W3C.  These are some small edits to help in such contexts.