### PR TITLE
New group pages

### DIFF
--- a/chair/role.html
+++ b/chair/role.html
@@ -56,8 +56,7 @@ working groups.</li>
 <li>Participates in the Chairs mailing list (<a href="https://lists.w3.org/Archives/Member/chairs/">archive</a>) and attends Chairs
 meetings.<br />
 <em>the team contact should make sure the chair is in the</em>
-<a href="/2000/09/dbwg/details?group=31972"><em>chairs
-group</em></a></li>
+<a href="/admin/othergroups/31972/show"><em>chairs group</em></a> (should be managed automatically)</li>
 <li>Works with the Communications Team and Staff Contact in preparing press release.</li>
 <li>Communicates with the press, when necessary and appropriate,
 and with prior coordination with the communication team, on behalf

--- a/index.html
+++ b/index.html
@@ -88,8 +88,7 @@
         <li><a href="https://www.w3.org/Guide/chair/buddy.html">W3C Chair Buddy System</a></li>
         <li><a href="https://www.w3.org/Consortium/activities">List of groups</a></li>
         <li><a href="https://lists.w3.org/">Mailing list archive search</a></li>
-        <li>Databases: <a href="https://www.w3.org/Consortium/activities">Groups</a>, <a href="https://www.w3.org/2000/09/dbwg/">Participants
-            (dbwg)</a></li>
+        <li>Databases: <a href="https://www.w3.org/groups">Groups</a></li>
         <li>Calendars: <a href="https://www.w3.org/participate/eventscal.html">Face-to-Face
             Meetings</a></li>
         <li>Mailing list archives: <a href="https://www.w3.org/Archives/Member/chairs/">chairs</a>

--- a/participant/group.html
+++ b/participant/group.html
@@ -84,7 +84,7 @@
 
 <h3 id="group_pages">List of the W3C groups</h3>
 <ul>
-  <li><a href="https://www.w3.org/Member/Groups">Working Groups/Interest Groups</a></li>
+  <li><a href="https://www.w3.org/groups/">Working Groups/Interest Groups</a></li>
   <li><a href="https://www.w3.org/community/groups/">Business Groups/Community Groups</a></li>
 </ul>
 
@@ -135,7 +135,7 @@
 <h3 id="meetings">Meetings</h3>
 <ul>
   <li><a href="https://www.w3.org/participate/meetings.html">W3C Member meetings</a></li>
-  <li><a href="https://www.w3.org/2002/09/TPOverview.html">TPAC (Techincal Plenary and Advisory Committee Meetings</a></li>
+  <li><a href="https://www.w3.org/2002/09/TPOverview.html">TPAC (Technical Plenary and Advisory Committee Meetings</a></li>
   <li><a href="https://www.w3.org/Member/Meeting/">AC Meeting (Advisory Committee meeting)</a></li>
   <li>Other group specific f2f meetings: see group pages</li>
 </ul>
@@ -146,7 +146,7 @@
     <ul>
       <li><a href="https://w3c.github.io/specs.html">W3C Specs on GitHub</a></li>
       <li><a href="https://www.w3.org/2006/tools/wiki/Github">W3C Tools Support Wiki</a></li>
-      <li><a hrref="https://labs.w3.org/echidna/">Echidna (Automatic publication system)</a></li>
+      <li><a href="https://labs.w3.org/echidna/">Echidna (Automatic publication system)</a></li>
     </ul>
   </li>
   <li>Repository Manager:

--- a/participant/groupinfo.js
+++ b/participant/groupinfo.js
@@ -68,7 +68,7 @@ async function groupInfo(groupId) {
 
     // Some additional useful links
   group["details"] = `https://www.w3.org/2000/09/dbwg/details?group=${groupId}&order=org&public=1`;
-  group["edit"] = `https://www.w3.org/2011/04/dbwg/group-services?gid=${groupId}`;
+  group["edit"] = `https://www.w3.org/admin/groups/${groupId}/show`;
 
   // the dashboard knows about spec milestones and a subset of GH repositories issues
   group["dashboard"] = {

--- a/process/charter.html
+++ b/process/charter.html
@@ -96,7 +96,7 @@ Document on Groups</a></li>
 href="https://www.w3.org/2004/01/pp-impl/">IPP</a></li>
 
 <li><a
-href="https://www.w3.org/2000/09/dbwg/">DBWG</a></li>
+href="https://www.w3.org/groups/">Groups</a></li>
 </ul>
 </div>
 
@@ -523,14 +523,14 @@ Announcement of Director's Decision, Call for Participation</a></h2>
 <li>W3M has approved the group, whether or not preceded by an Advisory Committee Review</li>
 <li>There is a public home page for the group</li>
 <li>The group exists in IPP. If the group does not exist in IPP then
-contact w3t-comm@w3.org to <a href="/groups/new">create the group</a>. Note that this requires:
+contact w3t-comm@w3.org to <a href="/admin/dashboard">create the group</a>. Note that this requires:
   <ul>
     <li>group name,</li>
     <li>charter URI,</li>
     <li>home page URI</li>
     <li>whether the group accepts public invited experts.</li>
   </ul>
-Creating the group will give a (dbwg) group identifier that lists the group in the drop-down for db-backed groups in the mailing list creation form.</li>
+Creating the group will give a group identifier that lists the group in the drop-down for db-backed groups in the mailing list creation form.</li>
 <li>All relevant mailing lists exist. If not, Team Contact may <a href="/Systems/Mail/Request/">create the mailing list(s)</a>.</li>
 <li>The main mailing list is associated with the group via the <a href="/2011/04/dbwg/group-services">Group Service Management</a> interface (this updates automatically the <a href="/Member/Mail/">list of groups</a>.)</li>
 </ol>
@@ -593,7 +593,7 @@ for People to Join the Group</a></h3>
 depends on several factors.</p>
 
 <ul>
-<li>For WGs, IGs that are more than mailing lists, Systeam (or Head of Communications) <a href="/groups/new">add the group to IPP</a> (send a sysreq, cc:w3t-comm; Note that this requires a group name, charter URI, and home page URI; and whether the group accepts public invited experts. Creating the group will give a (dbwg) group identifier that will be used in mailing list requests).
+<li>For WGs, IGs that are more than mailing lists, Systeam (or Head of Communications) <a href="/admin/dashboard">creates the group</a> (send a sysreq, cc:w3t-comm; Note that this requires a group name, shortname, charter URI, and home page URI; and whether the group accepts public invited experts. Creating the group will give a group identifier that will be used in mailing list requests).
 <ul>
 <li>If the group is already managed by <a
 href="/2004/01/pp-impl/">IPP</a>, simply reuse the
@@ -609,13 +609,13 @@ href="/2004/01/pp-impl/">IPP home page</a>.</li>
 Policy (either a Working Group or an Interest Group with disclosure
 obligations that is more than a mailing list), the Team Contact sends
 a <a href="/2000/09/dbwg/docs#chairs">request to the Systems Team</a>
-to add the group to IPP (see <a href="https://www.w3.org/groups/new">interface to create a new group</a>).
+to add the group to IPP (see <a href="https://www.w3.org/admin/dashboard">interface to create a new group</a>).
 -->
 
-<p>If you wish also for DBWG to
-provide a public, simplified list of group participants, ask
-sysreq to enable that in your request (per the
-<a href="/2000/09/dbwg/docs#public">dbwg documentation</a>).</p>
+<p>
+    All Working Groups and Interest Groups appear in their respective <a href="/groups/">group list</a> and have a
+    public list of participants (except for Interest Groups that are not managed by IPP).
+</p>
 
 <!--
 <p>In the case of other groups (not managed by IPP), the Team Contact
@@ -696,9 +696,9 @@ obligations.</li>
 to this <a href="/2001/07/pubrules-copyright.xml">file used by several tools
 </a> such as the pubrules checker.</li>
 -->
-<li>The public <a href="/Consortium/activities">list of groups</a> is automatically updated from the Groups DB, including a 1-paragraph description.</li>
-<li>Team Contact marks the chair(s) as such in the Group's DBWG view (this adds the chair(s) to the
-<a href="https://www.w3.org/2000/09/dbwg/details?group=31972">Chairs' DBWG group</a>).</li>
+<li>The public <a href="/groups/">list of groups</a> is automatically updated from the Groups DB, including a 1-paragraph description.</li>
+<li>Team Contact marks the chair(s) as such in the Group's admin view (this automatically adds the chair(s) to the
+<a href="/admin/othergroups/31972/show">Chairs' group</a>).</li>
 <li>Function Lead or Staff Contact(s) update the Team's <a href="/2005/09/manage/">effort tables</a>.</li>
 </ul>
 


### PR DESCRIPTION
This PR fixes a few links and sentences related to legacy content that has now been replaced by new group pages.