### PR TITLE
link + caveat

### DIFF
--- a/process/banning.html
+++ b/process/banning.html
@@ -55,6 +55,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 <li>from a single group that the individual has not formally joined, to the chair(s) of the group; and</li>
 <li>from all W3C groups, to the CEO and COO jointly.</li>
 </ul>
+<p>If the chair, team contact, CEO, COO are in any way involved as accused or accuser, they should recuse themselves from all discussions.</p>
 
 <p>2. Following violation of the <a href="https://www.w3.org/Consortium/cepc/">W3C Code of Ethics and Professional Conduct</a>, at least one warning by the chair(s), and at least one subsequent violation of the CEPC, chairs may temporarily or permanently suspend participation by a person who has not formally joined the group.</p>
 
@@ -66,7 +67,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 
 <p>5. Typically a suspension will encompass participation in all forms, including meetings, email, IRC, Github posting, etc. In no case may a person be blocked from seeing public information (e.g. mailing list or Github posts, public minutes).</p>
 
-<p>6. No individual may be banned from sending email to the W3C Ombuds team. (Bots may be banned.)</p>
+<p>6. No individual may be banned from sending email to the <a href="https://www.w3.org/Consortium/pwe/#ombuds">W3C Ombuds team</a>. (Bots may be banned.)</p>
 
 <p>7. The W3C Systems team may block spammers and others who abuse our systems.</p>
 

--- a/process/banning.html
+++ b/process/banning.html
@@ -55,7 +55,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 <li>from a single group that the individual has not formally joined, to the chair(s) of the group; and</li>
 <li>from all W3C groups, to the CEO and COO jointly.</li>
 </ul>
-<p>If the chair, team contact, CEO, COO are in any way involved as accused or accuser, they should recuse themselves from all discussions.</p>
+<p>If the chair, team contact, CEO, COO are involved as accused or accuser, they should recuse themselves from all discussions. For clause (2) the escalation is to another chair and may involve a <a href="https://www.w3.org/Consortium/pwe/#ombuds">W3C Ombuds</a> then to the CEO. For clause (3), a request to remove the CEO or COO from a group is not one that ought to be delegated. For clause (4), in extremis involving the CEO or COO, either should be able to act without the other.</p>
 
 <p>2. Following violation of the <a href="https://www.w3.org/Consortium/cepc/">W3C Code of Ethics and Professional Conduct</a>, at least one warning by the chair(s), and at least one subsequent violation of the CEPC, chairs may temporarily or permanently suspend participation by a person who has not formally joined the group.</p>
 
@@ -67,7 +67,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 
 <p>5. Typically a suspension will encompass participation in all forms, including meetings, email, IRC, Github posting, etc. In no case may a person be blocked from seeing public information (e.g. mailing list or Github posts, public minutes).</p>
 
-<p>6. No individual may be banned from sending email to the <a href="https://www.w3.org/Consortium/pwe/#ombuds">W3C Ombuds team</a>. (Bots may be banned.)</p>
+<p>6. No individual may be banned from sending email to the W3C Ombuds team. (Bots may be banned.)</p>
 
 <p>7. The W3C Systems team may block spammers and others who abuse our systems.</p>
 

--- a/process/banning.html
+++ b/process/banning.html
@@ -55,7 +55,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 <li>from a single group that the individual has not formally joined, to the chair(s) of the group; and</li>
 <li>from all W3C groups, to the CEO and COO jointly.</li>
 </ul>
-<p>If the chair, team contact, CEO, COO are involved as accused or accuser, they should recuse themselves from all discussions. For clause (2) the escalation is to another chair and may involve a <a href="https://www.w3.org/Consortium/pwe/#ombuds">W3C Ombuds</a> then to the CEO. For clause (3), a request to remove the CEO or COO from a group is not one that ought to be delegated. For clause (4), in extremis involving the CEO or COO, either should be able to act without the other.</p>
+<p>If the chair, team contact, CEO, COO are involved as accused or accuser, they should recuse themselves from all discussions.</p>
 
 <p>2. Following violation of the <a href="https://www.w3.org/Consortium/cepc/">W3C Code of Ethics and Professional Conduct</a>, at least one warning by the chair(s), and at least one subsequent violation of the CEPC, chairs may temporarily or permanently suspend participation by a person who has not formally joined the group.</p>
 


### PR DESCRIPTION
The added paragraph under the 1st section addresses Tzviya's concern she shared with W3C Management.
Tzviya noted I had omitted to place a link on "ombuds", this PR fixes this as well.