### PR TITLE
remove "whether the group accepts public IE"

### DIFF
--- a/process/charter.html
+++ b/process/charter.html
@@ -526,9 +526,9 @@ Announcement of Director's Decision, Call for Participation</a></h2>
 contact w3t-comm@w3.org to <a href="/admin/dashboard">create the group</a>. Note that this requires:
   <ul>
     <li>group name,</li>
+    <li>group shortname</li>
     <li>charter URI,</li>
-    <li>home page URI</li>
-    <li>whether the group accepts public invited experts.</li>
+    <li>home page URI.</li>
   </ul>
 Creating the group will give a group identifier that lists the group in the drop-down for db-backed groups in the mailing list creation form.</li>
 <li>All relevant mailing lists exist. If not, Team Contact may <a href="/Systems/Mail/Request/">create the mailing list(s)</a>.</li>
@@ -593,7 +593,7 @@ for People to Join the Group</a></h3>
 depends on several factors.</p>
 
 <ul>
-<li>For WGs, IGs that are more than mailing lists, Systeam (or Head of Communications) <a href="/admin/dashboard">creates the group</a> (send a sysreq, cc:w3t-comm; Note that this requires a group name, shortname, charter URI, and home page URI; and whether the group accepts public invited experts. Creating the group will give a group identifier that will be used in mailing list requests).
+<li>For WGs, IGs that are more than mailing lists, Systeam (or Head of Communications) <a href="/admin/dashboard">creates the group</a> (send a sysreq, cc:w3t-comm; Note that this requires a group name, shortname, charter URI, and home page URI. Creating the group will give a group identifier that will be used in mailing list requests).
 <ul>
 <li>If the group is already managed by <a
 href="/2004/01/pp-impl/">IPP</a>, simply reuse the


### PR DESCRIPTION
It's no longer in the new group management system. IE application goes through separated app/approval process.