### PR TITLE
Update tense of distributed workshop planning

### DIFF
--- a/meetings/continuity.html
+++ b/meetings/continuity.html
@@ -228,8 +228,8 @@
       <h2 id='workshops'>W3C Workshops</h2>
 
       <p>
-            We intend to plan fully distributed <a href="https://www.w3.org/Consortium/Process/#GAEvents">workshops</a> with virtual presence sessions.
-		We will both adapt the existing model (program committee issues call for participation
+            We are also conducting fully distributed <a href="https://www.w3.org/Consortium/Process/#GAEvents">workshops</a> with virtual presence sessions.
+		We are adapting the existing model (program committee issues call for participation
 		and invites presentations based on submitted position statements) and experiment with new models.
 		In any format, materials should be posted and archived accessibly. Participants should be notified of plans for audio/video recording and confidentiality level.
       </p>


### PR DESCRIPTION
We are conducting distributed workshops now; it's [no longer in the future](https://www.w3.org/Guide/meetings/continuity#workshops).