### PR TITLE
Charter extension and update

### DIFF
--- a/process/charter.html
+++ b/process/charter.html
@@ -364,7 +364,7 @@ the <a href="/groups/">list of groups</a> accordingly.</p>
 	<li>When a charter is <strong>extended</strong>, the Team Contact (or Comm Team) modifies the Charter in place as follows:</li>
 <ul>
 <li>The "End Date" in the table at the top is modified in place.</li>
-<li>Any update to the Chair(s)(e.g., a Chair resigns or (re)appointed), Staff Contact(s)(e.g., names, FTEs), etc.</li>
+<li>Any update to the Chair(s) (e.g., a Chair resigns or is (re)appointed), Staff Contact(s) (e.g., names, FTEs), etc.</li>
 <li>The changes including extension history are documented in the "About this charter" section at the bottom and lists each extension dates and the pairs of from/until dates.</li>
 <li>The text "Note: The group will document significant changes from this initial schedule on the group home page." is updated with a link to the group's updated milestones
 (e.g., on the group's site) to say something like

--- a/process/charter.html
+++ b/process/charter.html
@@ -364,7 +364,7 @@ the <a href="/groups/">list of groups</a> accordingly.</p>
 	<li>When a charter is <strong>extended</strong>, the Team Contact (or Comm Team) modifies the Charter in place as follows:</li>
 <ul>
 <li>The "End Date" in the table at the top is modified in place.</li>
-<li>Any update to the Chair(s), Staff Contact(s), etc.</li>
+<li>Any update to the Chair(s)(e.g., a Chair resigns or (re)appointed), Staff Contact(s)(e.g., names, FTEs), etc.</li>
 <li>The changes including extension history are documented in the "About this charter" section at the bottom and lists each extension dates and the pairs of from/until dates.</li>
 <li>The text "Note: The group will document significant changes from this initial schedule on the group home page." is updated with a link to the group's updated milestones
 (e.g., on the group's site) to say something like
@@ -375,7 +375,7 @@ the <a href="/groups/">list of groups</a> accordingly.</p>
 	<li>Update the "Chair" in the table at the top.</li>
 	<li>Document changes in "About this charter" section at the bottom.</li>
 	</ul>
-	<li>When there's <strong>editorial change</strong> to the charter, in which case no announcement to w3c-ac-members@w3.org and cc's chairs@w3.org is required, Team Contact modifies the charter timely, e.g., update Team Contacts (names, FTE), fix editorial errors (broken links, typos, etc.).</li>
+	<li>When there's <strong>editorial change</strong> to the charter, in which case no announcement to w3c-ac-members@w3.org and cc's chairs@w3.org is required, Team Contact modifies the charter timely, e.g., fix editorial errors (broken links, typos, etc.).</li>
 	</ul>
 
 <h2>5. <a id="cfr" name="cfr">Advisory Committee Review of the


### PR DESCRIPTION
Per [Process 2020](https://www.w3.org/2020/Process-20200915/#CharterReview), changes of Chairs or Team Contacts must be announced to AC.