### PR TITLE
Timeline expectation and guideline for charter creation

### DIFF
--- a/process/charter.html
+++ b/process/charter.html
@@ -736,7 +736,9 @@ Invited Experts</a>.</p>
 </p>
 
 <ol>
-  <li>At the minimum, you should expect a minimum of 4 months to get a charter approved for an existing group, starting from scratch.</li>
+  <li>You should be planning for 4 months to get a charter approved for a group, starting from scratch.
+    More may be needed if the scope or deliverables are controversial.
+  </li>
   <li>Some of the steps can be done in parallel.
     <ul>
       <li>request the advance notice from the strategy lead as soon as you have something to point to.</li>

--- a/process/charter.html
+++ b/process/charter.html
@@ -751,7 +751,7 @@ Invited Experts</a>.</p>
     </ul>
   </li>
   <li>Make sure to have the Project Management Lead (for existing groups) and/or the Strategy Lead in the
-    loops.</li>
+    loop.</li>
 </ol>
 
 <!--

--- a/process/charter.html
+++ b/process/charter.html
@@ -399,7 +399,7 @@ Any Advisory Committee representative may request an extended review period of a
 any such request, the Director must ensure that the Call for Participation for the Working Group occurs at least 60 days after the Call for Review of the charter.
 </p>
 
-<p class=timeline><em>Timeline:</em> this takes 7 weeks months minimum. Formal objections to a charter will
+<p class=timeline><em>Timeline:</em> this takes 5 weeks minimum. Formal objections to a charter will
   add more time.</p>
 
 <h3>5.1 Organizing the Call for Review</h3>

--- a/process/charter.html
+++ b/process/charter.html
@@ -43,6 +43,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
    <li><a href="#extension">Charter Extension</a> &bull;</li>
    <li><a href="#cfr">AC Review</a> &bull;</li>
    <li><a href="#director-decision">Director's Decision, Call for Participation</a></li>
+   <li><a href="#timeline">Timeline</a></li>
  </ul>
 </div>
 
@@ -130,6 +131,9 @@ href="https://www.w3.org/Consortium/Process/#WGCharter">list
 of charter requirements</a> to ensure that your charter is complete
 (e.g., it includes a duration for the group).</p>
 
+<p class=timeline><em>Timeline:</em> For existing groups, this takes no time. For new groups, it may take one month or more for W3M
+  to start dedicating resources.</p>
+
 <h2 id="advance">2. Advance Notice</h2>
 
 <!-- Resolved at W3M 11 July 2007 -->
@@ -147,6 +151,8 @@ notice; see the <a href="https://www.w3.org/new-doc-from-template?location=%2FTe
 Send Advance Notice of Work to the Advisory Committee</a> for more
 information.</p>
 
+<p class=timeline><em>Timeline:</em> This takes a week at most.</p>
+
 <h2>3. <a id="creation" name="creation">Charter Creation</a></h2>
 
 <p>The Team Contact works with the Strategy Lead to
@@ -159,6 +165,9 @@ The Team Contact may wish to share drafts of the provisional
 charter with a candidate Chair (if one exists), a relevant interest
 group or interested community of W3C members prior to Member
 review.</p>
+
+<p class=timeline><em>Timeline:</em> due to the discussion needing to happen with the community and the need
+  for horizontal review, this takes 1.5 to 4 months for existing groups.</p>
 
 <h3>3.1 Patent Policy Section for a Working Group Charter</h3>
 
@@ -344,7 +353,9 @@ The Strategy or Project Lead (or delegate) informs the Comm Team of W3M approval
 by sending email to <a
 href="mailto:w3t-comm@w3.org">w3t-comm@w3.org</a>, or the Head of Communications forwards the W3M action for information.</p>
 
-<h3 id="extension">Charter Extension and Update</h3>
+<p class=timeline><em>Timeline:</em> this takes 2 weeks.</p>
+
+  <h3 id="extension">Charter Extension and Update</h3>
 
 <p><strong>Note:</strong> Is the Group aware that its charter is being extended? Please inform the group before discussion within W3M.</p>
 
@@ -387,6 +398,9 @@ The Director is not required to solicit Advisory Committee review prior to a cha
 Any Advisory Committee representative may request an extended review period of any new or substantively modified Working Group charter, if submitted with a Member’s comments in response to the Call for Review (see <a href="https://www.w3.org/new-doc-from-template?location=%2FTeam%2Ftemplates&amp;template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcharter-extension.html&amp;submit=Continue...">extension template</a>). Upon receipt of
 any such request, the Director must ensure that the Call for Participation for the Working Group occurs at least 60 days after the Call for Review of the charter.
 </p>
+
+<p class=timeline><em>Timeline:</em> this takes 7 weeks months minimum. Formal objections to a charter will
+  add more time.</p>
 
 <h3>5.1 Organizing the Call for Review</h3>
 
@@ -546,6 +560,7 @@ message is clear. In general, the Comm Team sends one email for group approval (
 <a
 href="https://www.w3.org/new-doc-from-template?location=%2FTeam%2FTemplates&amp;template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcfp.html&amp;submit=Continue...">template for the call for participation</a>.</p>
 
+<p class=timeline><em>Timeline:</em> this takes a week at most.</p>
 
 <h3>6.1 Organizing the Director's Decision</h3>
 
@@ -713,6 +728,29 @@ to this <a href="/2001/07/pubrules-copyright.xml">file used by several tools
 Invited Expert joins a group should consult the <a
 href="https://www.w3.org/2004/02/invited_expert">Team Policy for
 Invited Experts</a>.</p>
+
+<h2 id=timeline>Timeline for Charter creation</h2>
+
+<p>Depending on the complexity of the charter, the time to draft and get a charter approved by the W3C Director may vary greatly.
+  Each section above gives expectation on how long it takes. This section gives guidance on how to manage the overall timeline.
+</p>
+
+<ol>
+  <li>At the minimum, you should expect a minimum of 4 months to get a charter approved for an existing group, starting from scratch.</li>
+  <li>Some of the steps can be done in parallel.
+    <ul>
+      <li>request the advance notice from the strategy lead as soon as you have something to point to.</li>
+      <li>Start the horizontal reviews of the charter as soon as the scope, deliverables, and dependencies
+         parts of the charter are stable enough. Ping the horizontal reviwer on a weekly basis.</li>
+      <li>start working on resolving any formal objection on a charter as soon as those received. Don't wait
+        for the end of the AC review period.
+      </li>
+      <li>prepare your Director approval announcement before getting the approval from W3M</li>
+    </ul>
+  </li>
+  <li>Make sure to have the Project Management Lead (for existing groups) and/or the Strategy Lead in the
+    loops.</li>
+</ol>
 
 <!--
 <h3><a name="cfe">7.4 Organizing a Call for Exclusions</a></h3>


### PR DESCRIPTION
This is intended to help team contacts in managing the time around creating charters and getting them approved by  the W3C Director.