### PR TITLE
clarity rewrites of timezone branch

### DIFF
--- a/meetings/organize.html
+++ b/meetings/organize.html
@@ -47,8 +47,8 @@
       </div>
 
       <p>
-        W3C benefits from a diverse, inclusive, and worldwide participation. This document provides guidance
-        to meeting Chairs for organizing distributed meetings.
+        W3C benefits from diverse, inclusive, and worldwide participation. This document provides guidance
+        to those organizing distributed meetings.
       </p>
 
       <h2 id='timezones'>Dealing with timezones</h2>
@@ -58,36 +58,33 @@
                (e.g., by telephone, video conferencing, or IRC).</p>
             <p>&mdash; <a href='https://www.w3.org/Consortium/Process/#distributed-meeting'>W3C Process Document</a></p>
       </blockquote>
-      <p>A chair should build consensus towards finding a suitable time slot for a distributed meeting.</p>
+      <p>A chair should build consensus towards finding a suitable time slot for a distributed meeting and should
+	 reevaluate that consensus on a regular basis, e.g. every 6 months.</p>
 
-      <p>A chair should consider the following steps for proposing time slots:
+      <p>A chair might use the following steps for proposing time slots:
       <ul>
-        <li>Ask the preferred time zones (including the info of daylight-saving time) of group participants</li>
-        <li>Propose candidate time slots, at least, including time slots starting
-                from 6:00 am and ending at 0:00 am at each time zone area of the group participants
+        <li>Collect participant's time zones</li>
+        <li>Propose candidate time slots, at least some of which start beween 6:00am and 12:00am in each participant's timezone
                 (see <a href="https://www.timeanddate.com/worldclock/meetingtime.html?iso=20210127&p1=240&p2=248&p3=33&p4=195&p5=136&p6=43&p7=64&p8=224">World Clock Meeting Planner</a>)
         </li>
         <li>Propose alternate time slots of a regular distributed meeting per a period, e.g. 3 or
             6 months</li>
-        <li>Use any tool, e.g., doodle.com, to collect feedback on proposed time slots but should
-              use an alternative way if a member claims the tool is not available</li>
+        <li>If using a tool such as doodle.com to collect feedback, provide alternative mechanisms to participants who
+	have trouble accessing the tool</li>
       </ul>
       <p>A Chair should consider the following for deciding on time slots:</p>
       <ul>
-        <li>Prioritize preferences of core participants depending on the meeting agenda</li>
+        <li>Prioritize preferences of core participants based on the meeting agenda</li>
         <li>Prioritize the major preference of the other members but should take account that a
                   preference of the majority in a time zone area has an equivalent priority to
                   those of the majority in other time zone areas.</li>
-         <li>If the group can not reach a consensus, the Chair has the prerogative to make
-               the decision based on their own judgment.</li>
-         <p>Revisit the consensus of the time slots on a regular basis, e.g. every 6 months</li>
+         <li>If the group can not reach a consensus, the Chair has the discretion to make
+               the decision.</li>
       </ul>
 
-      <p>Per the <a href="https://www.w3.org/Consortium/Process/#GeneralMeetings">W3C process Document</a>,
-            the Chair is required to provide the agenda and the materials of the meeting available at
-            least 24 hours in advance (or longer if a meeting is scheduled after a weekend or holiday).
-      In addition, a Chair should announce the distributed meeting with the proper meeting arrangements, and
-      through proper channels (mailing lists, group pages, etc.)</p>
+      <p>The <a href="https://www.w3.org/Consortium/Process/#GeneralMeetings">W3C Process</a>,
+	  provides rules about the timing of meeting announcements and meeting agendas.
+      </p>
       </li>
       </ul>
 

--- a/meetings/organize.html
+++ b/meetings/organize.html
@@ -72,7 +72,7 @@
         <li>If using a tool such as doodle.com to collect feedback, provide alternative mechanisms to participants who
 	have trouble accessing the tool</li>
       </ul>
-      <p>A Chair should consider the following for deciding on time slots:</p>
+      <p>A Chair should consider the following when judging the group's consensus:</p>
       <ul>
         <li>Prioritize preferences of core participants based on the meeting agenda</li>
         <li>Prioritize the major preference of the other members but should take account that a
@@ -82,8 +82,8 @@
                the decision.</li>
       </ul>
 
-      <p>The <a href="https://www.w3.org/Consortium/Process/#GeneralMeetings">W3C Process</a>,
-	  provides rules about the timing of meeting announcements and meeting agendas.
+      <p>The <a href="https://www.w3.org/Consortium/Process/#GeneralMeetings">W3C Process</a>
+	  provides rules about the timing of meeting announcements and agenda publication.
       </p>
       </li>
       </ul>

--- a/meetings/organize.html
+++ b/meetings/organize.html
@@ -58,28 +58,26 @@
                (e.g., by telephone, video conferencing, or IRC).</p>
             <p>&mdash; <a href='https://www.w3.org/Consortium/Process/#distributed-meeting'>W3C Process Document</a></p>
       </blockquote>
-      <p>A chair should build consensus towards finding a suitable time slot for a distributed meeting and should
+      <p>A chair should build consensus about the time slots for distributed meetings and should
 	 reevaluate that consensus on a regular basis, e.g. every 6 months.</p>
 
       <p>A chair might use the following steps for proposing time slots:
       <ul>
-        <li>Collect participant's time zones</li>
+        <li>Collect participants' time zones</li>
         <li>Propose candidate time slots, at least some of which start beween 6:00am and 12:00am in each participant's timezone
                 (see <a href="https://www.timeanddate.com/worldclock/meetingtime.html?iso=20210127&p1=240&p2=248&p3=33&p4=195&p5=136&p6=43&p7=64&p8=224">World Clock Meeting Planner</a>)
         </li>
-        <li>Propose alternate time slots of a regular distributed meeting per a period, e.g. 3 or
-            6 months</li>
         <li>If using a tool such as doodle.com to collect feedback, provide alternative mechanisms to participants who
 	have trouble accessing the tool</li>
       </ul>
-      <p>A Chair should consider the following when judging the group's consensus:</p>
+      <p>A chair should consider the following when judging the group's consensus:</p>
       <ul>
         <li>Prioritize preferences of core participants based on the meeting agenda</li>
         <li>Prioritize the major preference of the other members but should take account that a
                   preference of the majority in a time zone area has an equivalent priority to
                   those of the majority in other time zone areas.</li>
          <li>If the group can not reach a consensus, the Chair has the discretion to make
-               the decision.</li>
+               a decision.</li>
       </ul>
 
       <p>The <a href="https://www.w3.org/Consortium/Process/#GeneralMeetings">W3C Process</a>


### PR DESCRIPTION
Proposed rewrites for clarity.  Does not fix the [bullet item I don't understand](https://github.com/w3c/Guide/pull/112#issuecomment-769158287).  

"revisit" was in both the first list - very awkwardly worded - and again _after_ the second list.  I moved it to the top of the doc and deleted the awkward text.  Feel free to rearrange it.

This PR is based on the timezones branch.

[Preview](https://raw.githack.com/w3c/Guide/timezones-2/meetings/organize.html)