### PR TITLE
added "operations in travel restrictions" to section "guidelines and …

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,6 +337,7 @@
 	<li><a href="https://www.w3.org/2004/06/NoNDAPolicy.html">NDAs and W3C Meetings</a></li>
 	<li><a href="https://www.w3.org/2013/09/normative-references">Normative References guidelines</a></li>
 	<li><a href="https://www.w3.org/2017/12/formal-objections.html">Processing of Formal Objections</a></li>
+	<li><a href="https://www.w3.org/Guide/meetings/continuity.html">Continuity of Operations under Travel Restrictions</a></li>
       </ul>
     </div>
     <p style="clear: both"><strong>Note on Member Submissions: </strong> Per <a


### PR DESCRIPTION
…policies"

The W3C team travel policy lives as an archived mail to the W3C team and therefore is hard to link in /Guide or anywhere. But since we developed "Continuity of Operations under Travel Restrictions" which talks about travels (including w3c staff’s) and meetings during the pandemic, I see this as a good addition to the "guidelines and policies" section of the guidebook.

It also addresses one aspect of the [Advisory Board's issue-8](https://github.com/w3c/AB-memberonly/issues/8) that @chaals raised late 2019 (and that I became aware of today).