### PR TITLE
Group creation updates

### DIFF
--- a/process/charter.html
+++ b/process/charter.html
@@ -94,9 +94,6 @@ href="https://www.w3.org/Consortium/Process/#GAGeneral">Process
 Document on Groups</a></li>
 
 <li><a
-href="https://www.w3.org/2004/01/pp-impl/">IPP</a></li>
-
-<li><a
 href="https://www.w3.org/groups/">Groups</a></li>
 </ul>
 </div>
@@ -538,31 +535,30 @@ Announcement of Director's Decision, Call for Participation</a></h2>
 
 <ol>
 <li>W3M has approved the group, whether or not preceded by an Advisory Committee Review</li>
-<li>There is a public home page for the group</li>
-<li>Create a Mechanism for People to Join the Group. The mechanism that people will use to join the group depends on several factors.
+<li>The group exists in the Groups DB.
 <ul>
-    <li>For WGs, IGs that are more than mailing lists</li>
-  </ul>
-  <ul>
+  <li>If the group does not exist.<br>
+  Contact the W3C Communications Team to <a href="/admin/dashboard">create the group</a> by sending a mail to <a href="mailto:w3t-comm@w3.org">w3t-comm@w3.org</a>. Note that this requires:
     <ul>
-      <li>If the group is already managed by <a href="/2004/01/pp-impl/">IPP</a>, simply reuse the
-      join form that IPP provides; all join pages are available from the <a href="/2004/01/pp-impl/">IPP home page</a>.</li>
-      <li>If the group does not exist in IPP, contact Systeam (or W3C Communications Team) to <a href="/admin/dashboard">create the group</a> (send a sysreq, cc:<a href="mailto:w3t-comm@w3.org">w3t-comm@w3.org</a>). Note that this requires:
-        
-<ul>
-          <li>group name</li>
-          <li>group shortname</li>
-          <li> charter URI</li>
-          <li>home page URI</li>
-        </ul>
-      Creating the group will give a group identifier that lists the group in the drop-down for db-backed groups in the mailing list creation form.
-      </li>
+      <li>group name</li>
+      <li>group shortname</li>
+      <li>charter URI</li>
+      <li>homepage URI <em>(only if you want to use a page different that the automatically generated <a href="/groups/">group pages</a>)</em></li>
     </ul>
-    <li>If the group is an IG that is just a mailing list, document on the group's home page that to join the group people subscribe to the list.</li>
-  </ul>
+    Creating the group will lists the group in the drop-down for db-backed groups in the mailing list creation form.
   </li>
+  <li>If the group already exists
+    <ul>
+      <li>For WGs and IGs that are more than mailing lists.<br>
+      Simply reuse the existing join form; all join pages are available from the <a href="/groups/">list of groups</a>.</li>
+      <li>If the group is an IG that is just a mailing list.<br>
+      Document on the group's home page that to join the group people subscribe to the list.</li>
+    </ul>
+  </li>
+</ul>
+</li>
 <li>All relevant mailing lists exist. If not, Team Contact may <a href="/Systems/Mail/Request/">create the mailing list(s)</a>.</li>
-<li>The main mailing list is associated with the group via the <a href="/2011/04/dbwg/group-services">Group Service Management</a> interface (this updates automatically the <a href="/groups/">list of groups</a>.)</li>
+<li>The main mailing list is associated with the group via the <a href="/2011/04/dbwg/group-services">Group Service Management</a> interface.</li>
  <li>Make sure the charter is public (since 2007, charters are public during AC review) and any final edits (e.g., addition of link to page for joining the group) have been made.</li>
 </ol>
 
@@ -638,8 +634,7 @@ has the latest charter link (the W3C Communications team <a href="https://www.w3
 <li>If the group is using IPP as the join mechanism,
 the W3C Communications Team uses the <a href="https://www.w3.org/admin/dashboard">Groups DB</a> interface to
 record that a Call for Participation was sent (so that all links via the Groups DB, including the charter one on the IPP join form, are actually live).</li>
-<li>If the group was "staged", Systeam or W3C Communications Team unstages it.</li>
-<li>The <a href="/groups/">list of groups</a> is automatically updated from the Groups DB.</li>
+<li>If the group was "staged", W3C Communications Team unstages it.</li>
 <li>The public <a href="/groups/">list of groups</a> is automatically updated from the Groups DB, including a 1-paragraph description.</li>
 <li>Team Contact marks the chair(s) as such in the Group's admin view (this automatically adds the chair(s) to the
 <a href="/admin/othergroups/31972/show">Chairs' group</a>).</li>
@@ -716,7 +711,7 @@ working groups</a> and discussion within the Team and Advisory Board.</li>
 <li><strong>2018-01</strong>: Took latest process into account</li>
 </ul>
 
-<hr >
+<hr>
 
 <address><a href="https://www.w3.org/People/CMercier/">Coralie Mercier</a> for
 <a href="https://www.w3.org/People/LeHegaret/">Philippe Le Hégaret</a>, guidebook editor<br>

--- a/process/charter.html
+++ b/process/charter.html
@@ -454,15 +454,6 @@ exist).</p>
 href="https://www.w3.org/2002/09/wbs/33280/apCFRFactory">Call for
 Review questionnaire</a>. The URI for the questionnaire is added to
 the Call for Review.
-<!--
-<strong>Note:</strong>
-The questionnaire builder
-produces questionnaires for groups under the W3C Patent Policy. Here
-is a <a href="https://www.w3.org/2002/09/wbs/33280/EOWG03/">sample of
-an old-style questionnaire</a> for a group under the CPP; the claims
-and licensing sections are relevant and should replace the W3C Patent
-Policy section of the newer questionnaires.
--->
 </p>
 
 <p>Once the Head of W3C Communications (or explicit delegate) has approved the Call for Review and the questionnaire, the W3C 
@@ -574,39 +565,11 @@ Announcement of Director's Decision, Call for Participation</a></h2>
 <li>The main mailing list is associated with the group via the <a href="/2011/04/dbwg/group-services">Group Service Management</a> interface (this updates automatically the <a href="/groups/">list of groups</a>.)</li>
  <li>Make sure the charter is public (since 2007, charters are public during AC review) and any final edits (e.g., addition of link to page for joining the group) have been made.</li>
 </ol>
-	
-<!--
-<p>In the case of a group making the transition to the W3C Patent
-Policy (either a Working Group or an Interest Group with disclosure
-obligations that is more than a mailing list), the Team Contact sends
-a <a href="/2000/09/dbwg/docs#chairs">request to the Systems Team</a>
-to add the group to IPP (see <a href="https://www.w3.org/admin/dashboard">interface to create a new group</a>).
--->
 
 <p>
     All Working Groups and Interest Groups appear in their respective <a href="/groups/">group list</a> and have a
     public list of participants (except for Interest Groups that are not managed by IPP).
 </p>
-
-<!--
-<p>In the case of other groups (not managed by IPP), the Team Contact
-creates a form for joining the group using WBS. Please use the <a
-href="https://www.w3.org/2002/09/wbs/33280/psig-20041217/">PSIG join
-form</a> as a starting point.</p>
--->
-
-<!--
-<p><strong>Note:</strong> For a group making the
-transition to IPP, initially IPP will
-list as participants all the participants that were listed in
-DBWG. However, after a grace period (forty-five days per the <a
-href="https://www.w3.org/2003/12/22-pp-faq.html#start">PP FAQ</a>),
-those participants who have not rejoined the group through IPP will
-not be permitted to attend meetings. If, after the grace period, there
-are discrepancies between the IPP view of participants and the DBWG
-view of participants, the W3C Communications Team will ask the Team Contact to help
-resolve them.</p>
--->
 
 <p>The W3C Communications Team should try to minimize the number of
 messages sent to the Advisory Committee, while ensuring that each
@@ -641,14 +604,7 @@ message is clear. In general, the W3C Communications Team sends one email combin
 	
 <p>The announcement must also indicate when appropriate:</p>
 
-<ul>
-  
-<!--
-<li>Whether this is a Working Group that is making the transition
-to the W3C Patent Policy and has Working Drafts that are expected
-to become Recommendations.</li>
--->
-  
+<ul> 
   <li>For a newly created group, information about the dates of the first face-to-face meeting.</li>
 </ul>
 
@@ -684,17 +640,6 @@ the W3C Communications Team uses the <a href="https://www.w3.org/admin/dashboard
 record that a Call for Participation was sent (so that all links via the Groups DB, including the charter one on the IPP join form, are actually live).</li>
 <li>If the group was "staged", Systeam or W3C Communications Team unstages it.</li>
 <li>The <a href="/groups/">list of groups</a> is automatically updated from the Groups DB.</li>
-<!--
-<li>If the group has just made the transition to the W3C Patent
-Policy, the W3C Communications Team sends out a <a href="#cfe">Call for
-Exclusions</a> for each specification with associated licensing
-obligations.</li>
--->
-<!--
-<li>If the group is new, add link(s) to the group home page(s)
-to this <a href="/2001/07/pubrules-copyright.xml">file used by several tools
-</a> such as the pubrules checker.</li>
--->
 <li>The public <a href="/groups/">list of groups</a> is automatically updated from the Groups DB, including a 1-paragraph description.</li>
 <li>Team Contact marks the chair(s) as such in the Group's admin view (this automatically adds the chair(s) to the
 <a href="/admin/othergroups/31972/show">Chairs' group</a>).</li>


### PR DESCRIPTION
@dontcallmedom noted that the instructions to create a group were a bit outdated.

I refreshed those and also removed some legacy text related to the transition to the Patent Policy which had already been commented in the HTML.