### PR TITLE
note about draft charter URIs

### DIFF
--- a/process/charter.html
+++ b/process/charter.html
@@ -428,7 +428,7 @@ Working Group participants are aware of the review.</p>
     be sent <strong>at least three business days before</strong> the anticipated start
     date of the review. The request must include:
     <ol>
-      <li>A URI to the proposed charter; this charter is public during the AC review.</li>
+      <li>A URI to the proposed charter (Note: avoid using github.io links); this charter is public during the AC review.</li>
       <li>The list of significant changes to a revised charter
 	(per <a href="https://www.w3.org/Consortium/Process/#CharterReview">section "Advisory Committee Review of a Working Group or Interest Group Charter"</a> of the Process Document). It is useful to include a diff between the current and proposed charters (You may wish to use the <a
             href="https://services.w3.org/htmldiff">HTML diff tool</a>).</li>


### PR DESCRIPTION
added note: avoid using github.io links for draft charters.