### PR TITLE
Adding an explicit link to group calendars

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,6 +154,7 @@
                 start guide</a> more details on setting up tools for managing an agenda,
               generating minutes, and updating issues lists</li>
             <li><a href="https://www.w3.org/Guide/1998/08/TeleconferenceHowTo">Scheduling teleconferences</a></li>
+	    <li><a href="https://www.w3.org/Guide/meetings/organize.html#calendars">Group calendars</a></li>
             <li><a href="https://www.w3.org/wiki/Holidays">Holidays wiki</a> to help planning WG
               work around recurring holidays</li>
             <li>Individual IRC tools ("bots"):


### PR DESCRIPTION
The current ["manual"](https://www.w3.org/Guide/meetings/organize.html#calendars) to the group calendaring system is fairly difficult to find; I believe it deserves its explicit link under the 'Running a Meeting' part.