### PR TITLE
Charter extension can only be up to 6 months

### DIFF
--- a/process/charter.html
+++ b/process/charter.html
@@ -358,6 +358,9 @@ href="mailto:w3t-comm@w3.org">w3t-comm@w3.org</a>.</p>
 
 <p>W3M resolved to adopt the <a href="https://www.w3.org/2015/04/charter-extensions.html">Policy on W3C Group Charter End Dates</a>, effective 18 June 2015.</p>
 
+<p>W3M amended the policy on 17 November 2021: charter extension can only be up to 6 months beyond the end date of the current charter. Any request for more than 6 months
+  MUST treated as <a href='#creation'>rechartering</a>.</p>
+
 <p>If W3M resolves to extend a charter, the Strategy or Project Lead (or delegate) sends e-mail to the
 W3C Communications Team in the form of an extension announcement; see the
 <a href="https://www.w3.org/new-doc-from-template?location=%2FTeam%2Ftemplates&amp;template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcharter-extension.html&amp;submit=Continue...">charter extension template</a>.</p>


### PR DESCRIPTION
Updated per November 17, 2021 W3M