### PR TITLE
Updates Guidelines for suspension or removal

### DIFF
--- a/process/banning.html
+++ b/process/banning.html
@@ -78,6 +78,7 @@ notified.</p>
       <ul>
         <li>If the participant is a W3C Member representative, the CEO will coordinate the response with the Member's Advisory Committee representative.</li>
         <li>If anyone raises an issue to the CEO that a participant fails to meet the requirements of <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">Individual Participation Criteria</a>, then the CEO is empowered to investigate. If the participant indeed is failing to meet those requirements, then after at least one warning and at least one subsequent violation, the CEO may temporarily or permanently suspend participation.</li>
+        <li>To avoid potential rapid escalation of unacceptable behavior, a W3C group chair and team contact may temporarily suspend a participant from a single group for up to 5 business days after alerting the CEO (and the Member's Advisory Committee representative if the participant is not an Invited Expert). Any subsequent suspension within 6 months would need to be requested from the CEO.</li>
       </ul>
     </li></ol>
 </li><li>

--- a/process/banning.html
+++ b/process/banning.html
@@ -69,7 +69,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 <li>
   <p>temporarily suspend participation for up to 5 business days if the person is a participant in the group after emailing the CEO (and the Member's Advisory Committee representative if the participant is not an Invited Expert).  Any subsequent suspension within 6 months would need to be requested from the CEO.</p>
 </li>
-<li>propose to suspend or remove a participant from a single group - typically for egregious and repetitive CEPC violations - by making a request to the CEO. If the participant is a W3C Member representative, the CEO will coordinate the response with the Member's Advisory Committee representative.</li>
+<li>propose to suspend or remove a participant from a single group by making a request to the CEO. If the participant is a W3C Member representative, the CEO will coordinate the response with the Member's Advisory Committee representative.</li>
 </li>
 </ol>
 </li>

--- a/process/banning.html
+++ b/process/banning.html
@@ -61,26 +61,20 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 </li>
 <li><p>In case of disagreement between the W3C group chair and team contact, each should explain their reasons to the CEO.</p></li>
 <li>
-<p>Following violation of the <a href="https://www.w3.org/Consortium/cepc/">W3C Code
-of Ethics and Professional Conduct</a>, a W3C group chair and team contact should
-give at least one written warning. If the participant was appointed by a Member,
-the Member's Advisory Committee representative must be notified.</p>
-</li>
-<li>
-  <p>Upon subsequent violation of the CEPC, a W3C group chair and team contact may:</p>
+  <p>Following violation of the <a href="https://www.w3.org/Consortium/cepc/">W3C Code of Ethics and Professional Conduct</a>, at least one warning by the chair(s), and at least one subsequent violation of the CEPC, a W3C group chair and team contact, acting together, may:</p>
   <ol>
 <li>
   <p>temporarily or permanently suspend participation by a person if the person has not formally joined the group.</p>
 </li>
 <li>
-<p>propose to suspend or remove a participant from a single group - typically for egregious and repetitive CEPC violations - by making a request to the CEO.</p>
-      <ul>
-        <li>If the participant is a W3C Member representative, the CEO will coordinate the response with the Member's Advisory Committee representative.</li>
-        <li>If anyone raises an issue to the CEO that a participant fails to meet the requirements of <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">Individual Participation Criteria</a>, then the CEO is empowered to investigate. If the participant indeed is failing to meet those requirements, then after at least one warning and at least one subsequent violation, the CEO may temporarily or permanently suspend participation.</li>
-        <li>To avoid potential rapid escalation of unacceptable behavior, a W3C group chair and team contact, acting together, may temporarily suspend a participant from a single group for up to 5 business days after alerting the CEO (and the Member's Advisory Committee representative if the participant is not an Invited Expert). Any subsequent suspension within 6 months would need to be requested from the CEO.</li>
-      </ul>
-    </li></ol>
-</li><li>
+  <p>temporarily suspend participation for up to 5 business days if the person is a participant the group after alerting the CEO (and the Member's Advisory Committee representative if the participant is not an Invited Expert).  Any subsequent suspension within 6 months would need to be requested from the CEO.</p>
+</li>
+<li>propose to suspend or remove a participant from a single group - typically for egregious and repetitive CEPC violations - by making a request to the CEO. If the participant is a W3C Member representative, the CEO will coordinate the response with the Member's Advisory Committee representative.</li>
+</li>
+</ol>
+</li>
+<li>If anyone raises an issue to the CEO that a participant fails to meet the requirements of <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">Individual Participation Criteria</a>, then the CEO is empowered to investigate. If the participant indeed is failing to meet those requirements, then after at least one warning and at least one subsequent violation, the CEO may temporarily or permanently suspend participation.</li>
+<li>
 <p>In extreme cases (such as death threats, or physical threats in general), the CEO and COO, acting together, may suspend or remove someone from participation in all groups. The CEO and COO must announce the action to W3C Management along with the rationale.</p>
 </li><li>
 <p>Typically a suspension will encompass participation in all forms, including meetings, email, IRC, Github posting, etc. In no case may a person be blocked from seeing public information (e.g. mailing list or Github posts, public minutes).</p>

--- a/process/banning.html
+++ b/process/banning.html
@@ -58,15 +58,28 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 <li>from all W3C groups, to the CEO and COO jointly.</li>
 </ul>
 <p>If the chair, team contact, CEO, COO is the one accused of unacceptable behavior, they should not be involved in the decision to ban.</p>
-</li><li>
-<p>Following violation of the <a href="https://www.w3.org/Consortium/cepc/">W3C Code of Ethics and Professional Conduct</a>, at least one warning by the chair(s), and at least one subsequent violation of the CEPC, chairs may temporarily or permanently suspend participation by a person who has not formally joined the group.</p>
-</li><li>
-<p>A W3C group chair and team contact may propose to suspend or remove a participant from a single group - typically for egregious and repetitive CEPC violations - by making a request to the CEO.</p>
+</li>
+<li><p>In case of disagreement between the W3C group chair and team contact, each should explain their reasons to the CEO.</p></li>
+<li>
+<p>Following violation of the <a href="https://www.w3.org/Consortium/cepc/">W3C Code
+of Ethics and Professional Conduct</a>, a W3C group chair and team contact should
+give at least one written warning. If the person is a is a W3C Member representative
+participant in the Group, the Member's Advisory Committee representative must be
+notified.</p>
+</li>
+<li>
+  <p>Upon subsequent violation of the CEPC, a W3C group chair and team contact may:</p>
+  <ol>
+<li>
+  <p>temporarily or permanently suspend participation by a person if the person has not formally joined the group.</p>
+</li>
+<li>
+<p>propose to suspend or remove a participant from a single group - typically for egregious and repetitive CEPC violations - by making a request to the CEO.</p>
       <ul>
-        <li>If the group chair and team contact are not in agreement, each should explain their reasons.</li>
         <li>If the participant is a W3C Member representative, the CEO will coordinate the response with the Member's Advisory Committee representative.</li>
         <li>If anyone raises an issue to the CEO that a participant fails to meet the requirements of <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">Individual Participation Criteria</a>, then the CEO is empowered to investigate. If the participant indeed is failing to meet those requirements, then after at least one warning and at least one subsequent violation, the CEO may temporarily or permanently suspend participation.</li>
       </ul>
+    </li></ol>
 </li><li>
 <p>In extreme cases (such as death threats, or physical threats in general), the CEO and COO, acting together, may suspend or remove someone from participation in all groups. The CEO and COO must announce the action to W3C Management along with the rationale.</p>
 </li><li>

--- a/process/banning.html
+++ b/process/banning.html
@@ -63,9 +63,8 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 <li>
 <p>Following violation of the <a href="https://www.w3.org/Consortium/cepc/">W3C Code
 of Ethics and Professional Conduct</a>, a W3C group chair and team contact should
-give at least one written warning. If the person is a is a W3C Member representative
-participant in the Group, the Member's Advisory Committee representative must be
-notified.</p>
+give at least one written warning. If the participant was appointed by a Member,
+the Member's Advisory Committee representative must be notified.</p>
 </li>
 <li>
   <p>Upon subsequent violation of the CEPC, a W3C group chair and team contact may:</p>
@@ -78,7 +77,7 @@ notified.</p>
       <ul>
         <li>If the participant is a W3C Member representative, the CEO will coordinate the response with the Member's Advisory Committee representative.</li>
         <li>If anyone raises an issue to the CEO that a participant fails to meet the requirements of <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">Individual Participation Criteria</a>, then the CEO is empowered to investigate. If the participant indeed is failing to meet those requirements, then after at least one warning and at least one subsequent violation, the CEO may temporarily or permanently suspend participation.</li>
-        <li>To avoid potential rapid escalation of unacceptable behavior, a W3C group chair and team contact may temporarily suspend a participant from a single group for up to 5 business days after alerting the CEO (and the Member's Advisory Committee representative if the participant is not an Invited Expert). Any subsequent suspension within 6 months would need to be requested from the CEO.</li>
+        <li>To avoid potential rapid escalation of unacceptable behavior, a W3C group chair and team contact, acting together, may temporarily suspend a participant from a single group for up to 5 business days after alerting the CEO (and the Member's Advisory Committee representative if the participant is not an Invited Expert). Any subsequent suspension within 6 months would need to be requested from the CEO.</li>
       </ul>
     </li></ol>
 </li><li>

--- a/process/banning.html
+++ b/process/banning.html
@@ -44,37 +44,41 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
         </li>
       </ul>
     </div>
-    
+
     <div id="Content">
 
 <p>The W3C process document empowers the Director to <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">suspend or remove participants from groups</a>. This document provides details about implementation and delegation.</p>
 
-<p>1. Consistent with the practices below, the Director delegates authority to suspend or remove participants:</p>
+<ol>
+<li>
+<p>Consistent with the practices below, the Director delegates authority to suspend or remove participants:</p>
 <ul>
 <li>from a single group, to the CEO;</li>
 <li>from a single group that the individual has not formally joined, to the chair(s) of the group; and</li>
 <li>from all W3C groups, to the CEO and COO jointly.</li>
 </ul>
 <p>If the chair, team contact, CEO, COO is the one accused of unacceptable behavior, they should not be involved in the decision to ban.</p>
-
-<p>2. Following violation of the <a href="https://www.w3.org/Consortium/cepc/">W3C Code of Ethics and Professional Conduct</a>, at least one warning by the chair(s), and at least one subsequent violation of the CEPC, chairs may temporarily or permanently suspend participation by a person who has not formally joined the group.</p>
-
-<p>3. A W3C group chair and team contact may propose to suspend or remove a participant from a single group - typically for egregious and repetitive CEPC violations - by making a request to the CEO.</p>
+</li><li>
+<p>Following violation of the <a href="https://www.w3.org/Consortium/cepc/">W3C Code of Ethics and Professional Conduct</a>, at least one warning by the chair(s), and at least one subsequent violation of the CEPC, chairs may temporarily or permanently suspend participation by a person who has not formally joined the group.</p>
+</li><li>
+<p>A W3C group chair and team contact may propose to suspend or remove a participant from a single group - typically for egregious and repetitive CEPC violations - by making a request to the CEO.</p>
       <ul>
         <li>If the group chair and team contact are not in agreement, each should explain their reasons.</li>
         <li>If the participant is a W3C Member representative, the CEO will coordinate the response with the Member's Advisory Committee representative.</li>
         <li>If anyone raises an issue to the CEO that a participant fails to meet the requirements of <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">Individual Participation Criteria</a>, then the CEO is empowered to investigate. If the participant indeed is failing to meet those requirements, then after at least one warning and at least one subsequent violation, the CEO may temporarily or permanently suspend participation.</li>
       </ul>
-<p>4. In extreme cases (such as death threats, or physical threats in general), the CEO and COO, acting together, may suspend or remove someone from participation in all groups. The CEO and COO must announce the action to W3C Management along with the rationale.</p>
-
-<p>5. Typically a suspension will encompass participation in all forms, including meetings, email, IRC, Github posting, etc. In no case may a person be blocked from seeing public information (e.g. mailing list or Github posts, public minutes).</p>
-
-<p>6. No individual may be banned from sending email to the W3C Ombuds team. (Bots may be banned.)</p>
-
-<p>7. The W3C Systems team may block spammers and others who abuse our systems.</p>
-
-<p>8. The W3C Systems team will provide technical support to implement suspensions.</p>
-
+</li><li>
+<p>In extreme cases (such as death threats, or physical threats in general), the CEO and COO, acting together, may suspend or remove someone from participation in all groups. The CEO and COO must announce the action to W3C Management along with the rationale.</p>
+</li><li>
+<p>Typically a suspension will encompass participation in all forms, including meetings, email, IRC, Github posting, etc. In no case may a person be blocked from seeing public information (e.g. mailing list or Github posts, public minutes).</p>
+</li><li>
+<p>No individual may be banned from sending email to the W3C Ombuds team. (Bots may be banned.)</p>
+</li><li>
+<p>The W3C Systems team may block spammers and others who abuse our systems.</p>
+</li><li>
+<p>The W3C Systems team will provide technical support to implement suspensions.</p>
+</li>
+</ol>
 <h3>Revision History</h3>
 <ul>
   <li>2020-08-28: Document becomes operational.</li>

--- a/process/banning.html
+++ b/process/banning.html
@@ -67,14 +67,15 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
   <p>temporarily or permanently suspend participation by a person if the person has not formally joined the group.</p>
 </li>
 <li>
-  <p>temporarily suspend participation for up to 5 business days if the person is a participant the group after emailing the CEO (and the Member's Advisory Committee representative if the participant is not an Invited Expert).  Any subsequent suspension within 6 months would need to be requested from the CEO.</p>
+  <p>temporarily suspend participation for up to 5 business days if the person is a participant in the group after emailing the CEO (and the Member's Advisory Committee representative if the participant is not an Invited Expert).  Any subsequent suspension within 6 months would need to be requested from the CEO.</p>
 </li>
 <li>propose to suspend or remove a participant from a single group - typically for egregious and repetitive CEPC violations - by making a request to the CEO. If the participant is a W3C Member representative, the CEO will coordinate the response with the Member's Advisory Committee representative.</li>
 </li>
 </ol>
 </li>
-<li>If anyone raises an issue to the CEO that a participant fails to meet the requirements of <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">Individual Participation Criteria</a>, then the CEO is empowered to investigate. If the participant indeed is failing to meet those requirements, then after at least one warning and at least one subsequent violation, the CEO may temporarily or permanently suspend participation.</li>
 <li>
+<p>If anyone raises an issue to the CEO that a participant fails to meet the requirements of <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">Individual Participation Criteria</a>, then the CEO is empowered to investigate. If the participant indeed is failing to meet those requirements, then after at least one warning and at least one subsequent violation, the CEO may temporarily or permanently suspend participation.</p>
+</li><li>
 <p>In extreme cases (such as death threats, or physical threats in general), the CEO and COO, acting together, may suspend or remove someone from participation in all groups. The CEO and COO must announce the action to W3C Management along with the rationale.</p>
 </li><li>
 <p>Typically a suspension will encompass participation in all forms, including meetings, email, IRC, Github posting, etc. In no case may a person be blocked from seeing public information (e.g. mailing list or Github posts, public minutes).</p>

--- a/process/banning.html
+++ b/process/banning.html
@@ -67,7 +67,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
   <p>temporarily or permanently suspend participation by a person if the person has not formally joined the group.</p>
 </li>
 <li>
-  <p>temporarily suspend participation for up to 5 business days if the person is a participant the group after alerting the CEO (and the Member's Advisory Committee representative if the participant is not an Invited Expert).  Any subsequent suspension within 6 months would need to be requested from the CEO.</p>
+  <p>temporarily suspend participation for up to 5 business days if the person is a participant the group after emailing the CEO (and the Member's Advisory Committee representative if the participant is not an Invited Expert).  Any subsequent suspension within 6 months would need to be requested from the CEO.</p>
 </li>
 <li>propose to suspend or remove a participant from a single group - typically for egregious and repetitive CEPC violations - by making a request to the CEO. If the participant is a W3C Member representative, the CEO will coordinate the response with the Member's Advisory Committee representative.</li>
 </li>


### PR DESCRIPTION
These changes allow:

1. Chair/TC is always expected to send a warning to the person before further actions
2. Allow Chair/TC to suspend a participant temporarily, instead of waiting for the CEO to step in
3. Make it clear that any disagreement between Chairs or TCs can be resolved by going to the CEO

This is a follow-up to https://github.com/w3c/w3process/issues/592

[Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwww.w3.org%2FGuide%2Fprocess%2Fbanning.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2FGuide%2Fsuspension-2022%2Fprocess%2Fbanning.html)