### PR TITLE
deactivate old charter when new charter is valid

### DIFF
--- a/process/charter.html
+++ b/process/charter.html
@@ -499,7 +499,12 @@ Notice in public-new-work to close the loop for the public record.</p>
 	<ul>
 		<li><a href="https://lists.w3.org/Archives/Team/w3t-comm/2021Jul/0084.html">2021-07-12 Update</a>: associate with a charter the 'W3C document license', the 'W3C software and document license' or both. The document licenses to be selected can be found in the section ‘Licensing’ of
 the charter itself. (Rationale: we need to record that bit in the charter admin interface in order to expose it in our API, in order to check that a document produced by a WG/IG is using the right document license.)</li>
-		<li>2022-07-19 Update: For recharter, deactivate the previous charter when a new charter is valid: 1) add a note to the previous charter indicating "This charter has been replaced by <a>[a newer version]</a>"; 2) if the previous charter hasn't expired by when a new charter is installed, deactivate the previous charter by changing its end date via <a href="<a href="https://www.w3.org/admin/dashboard">the charter admin interface</a>.</li>
+		<li>2022-07-19 Update: For recharters, deactivate the previous charter when a new charter is valid:
+			<ol>
+			<li>add a note to the previous charter indicating "This charter has been replaced by &lt;a&gt;[a newer version]&lt/a&gt";</li>
+			<li>if the previous charter hasn't expired when a new charter is installed, deactivate the previous charter by changing its end date via <a href="https://www.w3.org/admin/dashboard">the charter admin interface</a>.</li>
+			</ol>
+		</li>
 	</ul>
 	</li>
 <li>If the group is using IPP as the join mechanism,

--- a/process/charter.html
+++ b/process/charter.html
@@ -499,6 +499,7 @@ Notice in public-new-work to close the loop for the public record.</p>
 	<ul>
 		<li><a href="https://lists.w3.org/Archives/Team/w3t-comm/2021Jul/0084.html">2021-07-12 Update</a>: associate with a charter the 'W3C document license', the 'W3C software and document license' or both. The document licenses to be selected can be found in the section ‘Licensing’ of
 the charter itself. (Rationale: we need to record that bit in the charter admin interface in order to expose it in our API, in order to check that a document produced by a WG/IG is using the right document license.)</li>
+		<li>2022-07-19 Update: if the group's previous charter hasn't expired by when a new charter is installed, deactivate the previous charter by changing its end date via <a href="<a href="https://www.w3.org/admin/dashboard">the group admin page</a>.</li>
 	</ul>
 	</li>
 <li>If the group is using IPP as the join mechanism,

--- a/process/charter.html
+++ b/process/charter.html
@@ -499,7 +499,7 @@ Notice in public-new-work to close the loop for the public record.</p>
 	<ul>
 		<li><a href="https://lists.w3.org/Archives/Team/w3t-comm/2021Jul/0084.html">2021-07-12 Update</a>: associate with a charter the 'W3C document license', the 'W3C software and document license' or both. The document licenses to be selected can be found in the section ‘Licensing’ of
 the charter itself. (Rationale: we need to record that bit in the charter admin interface in order to expose it in our API, in order to check that a document produced by a WG/IG is using the right document license.)</li>
-		<li>2022-07-19 Update: if the group's previous charter hasn't expired by when a new charter is installed, deactivate the previous charter by changing its end date via <a href="<a href="https://www.w3.org/admin/dashboard">the group admin page</a>.</li>
+		<li>2022-07-19 Update: For recharter, deactivate the previous charter when a new charter is valid: 1) add a note to the previous charter indicating "This charter has been replaced by <a>[a newer version]</a>"; 2) if the previous charter hasn't expired by when a new charter is installed, deactivate the previous charter by changing its end date via <a href="<a href="https://www.w3.org/admin/dashboard">the charter admin interface</a>.</li>
 	</ul>
 	</li>
 <li>If the group is using IPP as the join mechanism,


### PR DESCRIPTION
This is a proposal to deactivate the old charter when a new charter is valid, for rechartering:
* update the old charter to properly direct people to the latest valid charter.
* end the previous charter in the group admin, so that there won't be two valid charters in parallel (possibly two Patent Policies) which would confuse our spec publication system.