### PR TITLE
add group calendar

### DIFF
--- a/participant/group.html
+++ b/participant/group.html
@@ -64,6 +64,10 @@
   <td><dl data-value="specifications"></dl></td>
 </tr>
 
+<tr>
+  <th>Calendar</th>
+  <td data-value="calendar"></td>
+</tr>
 
 </table>
 
@@ -252,6 +256,7 @@
               dl.appendChild(dd);
             }});
           }));
+        map("#calendar", `<a href="${group.homepage}/calendar">${group.homepage}/calendar</a>`);
 
         group["services"].then (data => {
           const services = getComponents("#services")[0];


### PR DESCRIPTION
Since all WG/IG/CG/BG should have a calendar page, @pchampin asked if the onboarding page could link to the group's calendar page.
That PR addresses the request.