### PR TITLE
Add a link to w3c/strategy when doing AC reviews

### DIFF
--- a/process/charter.html
+++ b/process/charter.html
@@ -290,6 +290,7 @@ Working Group participants are aware of the review.</p>
             href="https://services.w3.org/htmldiff">HTML diff tool</a>).</li>
 	<li>In case of renewal of an existing charter, whether the group scope has changed. E.g., are there any new deliverables with licensing obligations under the W3C Patent Policy? The current group participants would need to re-join the group once the revised charter is approved.</li>
       <li>A recommended review start date and duration (at least 28 days according to <a href="https://www.w3.org/Consortium/Process/#CharterReview">the process document</a>)</li>
+      <li>A URI to the review of the proposed charter in the <a href="https://github.com/w3c/strategy/issues">GitHub strategy repository</a></li>
       <li>The name of the Team-only mailing list for comments</li>
     </ol>
   </li>


### PR DESCRIPTION
Following a conversation on slack with @npdoty , it would good to point the AC to the pre-AC review of the charter