### PR TITLE
Council Guide

### DIFF
--- a/council/council.html
+++ b/council/council.html
@@ -194,7 +194,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
       <li><p>Once consultations are completed, the Chair of the W3C Council assesses the consensus of the Council, or if consensus cannot be found,
         calls for a vote of the W3C Council to sustain or overrule the Formal Objection.</p></li>
       <li><p>The W3C Council <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-decision">publishes its decision and its rationale</a>.</p></li>
-      <li><p>Whether the decision is to sustain or overrule, the W3C Council may include additional guidance for any of the participants involved (but see Light Touch below).</p></li>
+      <li><p>Whether the decision is to sustain or overrule, the W3C Council may include additional guidance for any of the participants involved.</p></li>
       <li><p>If the objection is sustained, the relevant group (i.e. Working Group, or Team developing a charter) may continue their work and develop a different proposal for their document.</p></li>
     </ul>
   </li>

--- a/council/council.html
+++ b/council/council.html
@@ -47,8 +47,8 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
     <div id="Content">
       <p>This document supplements the <span class="draft">[proposed]</span> Process Document by providing best practices to resolve and decide Formal Objections.</p>
 
-      <p>In this document, <em id="resolving">resolving</em> a Formal Objection means finding a solution that has no objections. <em id="deciding">Deciding</em> means 
-        giving a yes/no answer to the question of whether an objection should be <em id="overrule">overruled</em> (i.e. no) or <em id="sustained">sustained</em> (i.e. yes).
+      <p>In this document, <dfn id="resolving">resolving</dfn> a Formal Objection means finding a solution that has no objections. <dfn id="deciding">Deciding</dfn> means 
+        giving a yes/no answer to the question of whether an objection should be <dfn id="overrule">overruled</dfn> (i.e. no) or <dfn id="sustained">sustained</dfn> (i.e. yes).
       </p>
 
 <h2 id="council">Council</h2>

--- a/council/council.html
+++ b/council/council.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" >
+<title>W3C Council Guide</title>
+<link rel="stylesheet" href="/StyleSheets/generic-base-1.css" type="text/css">
+<link rel="stylesheet" type="text/css" href="assets/main.css">
+<link rel="shortcut icon" href="/Icons/WWW/Literature.gif">
+<link rel="start" href="../" >
+<style>
+  .IssueLabel-big {
+    font-weight: 600;
+    padding: 4px 8px;
+    border-radius: 3px;
+    line-height: 1.5;
+    box-sizing: border-box;
+    text-decoration: none;
+  }
+</style>
+</head>
+<body>
+
+<div id="header">
+<span class="logo"><a href="/"><img src="/Icons/WWW/w3c_home_nb"
+alt="W3C" height="48" width="72"></a></span>
+    <div class="breadcrumb">
+    <a href="/Member/">Member</a> &#x2192; <a href="/Guide/">The Art of
+Consensus</a> &#x2192;
+<h1>Council Guide</h1>
+</div>
+<p class="baseline">This <strong>Guidebook</strong> is the collected
+wisdom of the W3C Group Chairs and other collaborators.</p>
+</div>
+
+    <div class="toolbox box">
+      <h4>Nearby</h4>
+      <ul>
+        <li>
+          <a href="/Consortium/Process/">W3C Process Document</a>
+        </li>
+        <li>
+          <a href="/Consortium/cepc/">W3C Code of Ethics and Professional Conduct</a>
+        </li>
+      </ul>
+    </div>
+    
+    <div id="Content">
+      <p>This document supplements the <span class="draft">[proposed]</span> Process Document by providing best practices to resolve and decide Formal Objections.</p>
+
+      <p>In this document, <em id="resolving">resolving</em> a Formal Objection means finding a solution that has no objections. <em id="deciding">Deciding</em> means 
+        giving a yes/no answer to the question of whether an objection should be <em id="overrule">overruled</em> (i.e. no) or <em id="sustained">sustained</em> (i.e. yes).
+      </p>
+
+<h2 id="council">Council</h2>
+
+  <p>W3C aims to make decisions by consensus. If there are differences of opinions, groups work hard to understand different points of view and reach agreement, 
+    either by compromise, or by the force of some argument. When that is working well, Formal Objections are rare, indeed.
+  </p>
+
+  <p>W3C has substantial formal and informal processes to achieve consensus. The technical development process that results in W3C Recommendations requires that
+    raised Issues be addressed by Working Groups. It is a rare event that an issue gets to the Council's desk, and this only occurs after there has been a thorough airing
+    of all points of view in the relevant Working Group.
+  </p>
+  
+  <p>Similarly, most Working Group Charters are openly developed in Github. Advanced Notices inform the community when there is a new Charter to look at,
+    the Charter development process is open for people to raise issues and there is a fair effort to resolve issues prior to someone raising a Formal Objection.
+  </p>
+
+  <p>fact that Formal Objections should be rare does not de-legitimize any particular objection. On some issues there are legitimate differences of opinion
+    that require senior review. Some topics do not lend themselves to compromise, they are inherently yes/no decisions. It could be hard to find common ground.
+  </p>
+  
+  <p>Nonetheless, the fact that the process is oriented towards consensus implies that before an objection gets a senior review there already has been a great
+    deal of work on the issue. There is generally clarity on what the W3C decision was (that is being objected to). 
+    The objector, in trying to reverse the decision, has generally pulled together their best arguments and brought them to the group. 
+    The fact that so much work should be accomplished prior to senior review should make the effort to decide a Formal Objection easier.
+  </p>
+
+<h2 id="objection-types">The Team, the W3C Council, and different types of objections</h2>
+  <p>The Team has the responsibility to try to resolve a Formal Objection, or to come up with an analysis that might be used by the W3C Council
+   in deciding a Formal Objection. The Team takes the early steps in processing Formal Objections.
+  </p>
+  <p>There are different types of Formal Objections and W3C needs to make sure they are all handled properly.
+    Here are some interesting cases that are included herein:
+  </p>
+  <ol>
+    <li id="case-1"><p>There is a Formal Objection to a decision in a Working Group.
+      The Team as a disinterested bystander attempts to resolve the objection.
+      If it succeeds, W3C takes the path recommended by the Team.
+      If it fails, the Team prepares a report for the W3C Council.
+      The W3C Council decides.</p></li>
+    <li id="case-2"><p>The Team proposes a Charter to the W3C Advisory Committee and there are objections.
+      The Team attempts to resolve the objection even though they are not a disinterested bystander.
+      If it succeeds, W3C takes the recommended path.
+      If it fails, the Team prepares a report for the W3C Council.
+      The W3C Council decides.</p></li>
+    <li id="case-3"><p>The Advisory Board or TAG make a decision (e.g. on a process issue, or in a Statement emanating from a TAG finding) and there are objections.</p></li>
+  </ol>
+
+  <p>It is important that even though the Team is an interested party in <a href="#case-2">case 2</a>, and the AB or TAG could be interested parties in <a hred="#case-3">case 3</a>,
+    the overall process must provide the objectivity and transparency to give the W3C Community the confidence that such cases are handled fairly.</p>
+
+
+<h2 id="processing-of-formal-objections">Processing of Formal Objections</h2>
+  <p>All Formal Objections are made in response to a decision. Decisions are typically made by a Working Group as part of the Technical Report Development Process or
+    by the Team as part of an exercise to charter a new Group.
+  </p>
+
+  <p>Since W3C operates by consensus, it is always better if there can be a consensus between the group that made the original decision and the objector.
+    The first step in processing a formal objection is for the Team to see if it can find a consensus.
+    Even though that presumably has happened already in the Working Group, a new set of eyes might find new paths to resolution.
+    If resolution succeeds, then that resolution becomes the new decision.
+    If that is not successful, the Team prepares a detailed report with an analysis of the decision, objection, and its attempt to find a consensus.
+    That report may also contain a recommendation to favor either the decision or the objection.
+  </p>
+  
+  <p>This report is then sent to the W3C Council, to the deciders, and to the objectors.
+    The Council, like the Team before it, may try to find a consensus path forward.
+    Otherwise, the W3C Council uses input from the report, the deciders, and objectors to either overrule the objection (in which case the original decision is in force), or
+    to sustain the objection (in which case the original decision is vacated).
+    The W3C Council also writes a report explaining their decision, which may be based on the Team's report.
+  </p>
+
+<h3 id="team-fo">Team attempts to resolve Formal Objections</h3>
+  <p>When a Formal Objection is issued, the Team assigns someone to attempt to resolve the Formal Objection. 
+    That assignee is expected to follow the best practices below for this effort.
+  </p>
+
+  <p>Within the bounds set by the Process, the Team decides how long the assignee has to attempt resolution and to write the report before the decision will be taken to a W3C Council.
+    It is important that not too much time is spent in trying to resolve irreconcilable differences.
+    Appropriate timing will depend on the complexity of the issue, and on the cooperation of the objector(s) and decider(s).
+  </p>
+  
+  <p>The assignee should be well versed in the topic at hand. The assignee could be the Team Contact for the relevant Working Group, the person that drafted the Charter
+    that is being objected to, or another member of the Team who has familiarity with the situation.
+    It is important that the assignee be perceived as unbiased with respect to the decision under review, and it is extremely important that they execute this task in a way that is
+    as neutral and transparent as possible.
+  </p>
+  
+  <p>The assignee works with all participants to explore whether there is a way to resolve the Formal Objection.
+    If the assignee believes that they have succeeded then the assignee needs ample documentation that the objection is resolved.
+    Resolution requires both the satisfaction of the objectors and ensuring that the proposed resolution does not itself have objectors. Here are some examples:</p>
+
+  <ul>
+    <li><p>If the objectors no longer object to the original decision, there must be written documentation that they are withdrawing their objection.</p></li>
+    <li><p>If the resolution causes a change in a technical document, then there must be a Working Group call for consensus on the revised document in which there are no objections.</p></li>
+    <li><p>If the resolution causes a change in a proposed charter, then all participants in the AC review of that charter must have an opportunity to review the revised proposed charter.</p></li>
+  </ul>
+
+<h2 id="referral">Referral to W3C Council</h2>
+
+<p>If resolution is not possible in the allocated time frame, the assignee must refer the Formal Objection to the W3C Council for decision. The steps for that are as follows:</p>
+<ul>
+  <li>
+    <p>The assignee writes a report for the W3C Council summarizing the decision and the objection.</p>
+    <ul>
+      <li><p>The document is typically public.</p></li>
+      <li><p>If there are limited portions of the document which are confidential, there may be pointers to a separate confidential document.
+        These may be summarized in the main document without compromising confidential information.</p></li>
+      <li><p>The document should have a section in which both points of view are fairly expressed.</p></li>
+      <li><p>The document should include a list of who the objectors are. If that list is confidential, it may be in the separate document.</p></li>
+      <li><p>The document should list attempts to resolve the objection and why they failed.</p></li>
+      <li><p>The document may include the assignee's recommendations and rationale whether to sustain or overrule the objection</p></li>
+    </ul>
+  </li>
+  <li>
+    <p>The report should be available for review by the relevant groups and objectors</p>
+    <ul>
+      <li><p>If any participant feels that their viewpoint is not fairly represented, a limited time effort should be expended to get all relevant information into the document.</p></li>
+      <li><p>If at the end of the limited time effort the Team determines that it is not possible to get agreement on the summary document, then the Team publishes
+        their summary and notes which participants believe that it is not a fair summary. Those participants may write up their own viewpoints.</p></li>
+        <li><p>The assignee should indicate an explicit team contact (which can be the assignee) for comments on the draft document</p></li>
+    </ul>
+  </li>
+  <li>
+    <p>The W3C Council determines who will rule on this objection and who will chair the Council</p>
+    <ul>
+      <li><p>See <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-participation"Council Participation, Dismissal, and Renunciation</a> and 
+        <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-chairing">Council Chairing</a>.</p></li>
+      <li><p>Every person serving on the Council is expected to be sufficiently knowledgeable and thorough that they feel comfortable with the decision of the W3C Council.
+        The breadth of the Council membership, and therefore the participation of each of its members, is key to the Council’s ability to provide an appropriate
+        balance of viewpoints.</p></li>
+    </ul>
+  </li>
+  <li>
+    <p>In extraordinary circumstances, the Council may vote to <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-delegation">delegate</a> or
+      <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-short-circuit">short-circuit</a> its decision.</p>
+  </li>
+  <li>
+    <p>The W3C Council <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-deliberations">deliberates and reaches a decision</a> to sustain or overrule the prior decision</p>
+    <ul>
+      <li><p>If the W3C Council members deem that the written summaries are sufficient, they are not required to discuss with participants further, although they may
+        do so if they wish. They may consult with deciders and objectors if they wish. See thoroughness and fairness below.</p></li>
+      <li><p>Once consultations are completed, the Chair of the W3C Council assesses the consensus of the Council, or if consensus cannot be found,
+        calls for a vote of the W3C Council to sustain or overrule the Formal Objection.</p></li>
+      <li><p>The W3C Council <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-decision">publishes its decision and its rationale</a>.</p></li>
+      <li><p>Whether the decision is to sustain or overrule, the W3C Council may include additional guidance for any of the participants involved (but see Light Touch below).</p></li>
+      <li><p>If the objection is sustained, the relevant group (i.e. Working Group, or Team developing a charter) may continue their work and develop a different proposal for their document.</p></li>
+    </ul>
+  </li>
+</ul>
+
+<h2 id="nature-of-council-deliberations">The Nature of W3C Council deliberations</h2>
+
+<h3 id="considerations">I. Considerations</h3>
+
+<p>Each Formal Objection raised to the W3C Council has its own unique aspects associated with it, and the W3C Council needs the flexibility to choose how it reaches a decision.
+  In studying a particular Formal Objection, the W3C Council should always balance several factors:</p>
+<ul>
+  <li><p>Making the correct decision for the Web</p></li>
+  <li><p>Speed of decision making: that W3C does not get mired in objection processing</p></li>
+  <li><p>Understanding and empathy for the objector</p></li>
+  <li><p>Assuring that objection processing does not become a means for all decisions to be centralized at W3C</p></li>
+  <li><p>Avoiding micromanagement.</p></li>
+  <li><p>Treating all objectors consistently irrespective of who the objector might be.</p></li>
+  <li><p>Workload. If processing each Formal Objection results in a great deal of work for a very large Council, then
+    the Council will not have time to process the workload and the Council design will not scale.</p></li>
+</ul>
+
+<h3 id="convincing-the-council">II. Convincing the Council</h3>
+
+<p>The nature of a Formal Objection is that a Decision has been made and someone has lodged a Formal Objection to that Decision.
+  The W3C Council is required by the Process to review the Decision, and choose whether to overrule the objection or sustain the objection.
+  This section addresses the question about what information the Council has to consider.</p>
+
+<p>In any individual objection, the Council is empowered to find any resolution to the objection, and finding a consensus that is
+  supported by all is always preferred. Nothing in this discussion precludes such an approach or forces an adversarial judicial proceeding.
+  Nonetheless, there should be a clear expectation about the starting point for Council deliberations.</p>
+
+<p>Objectors should not be looking for the Council to come up with new arguments to support their point of view.
+  For example, if objectors have vague arguments of the form ”this is bad for privacy” or “this is bad for business”,
+  they should not expect the Council to do the research to demonstrate whether their vague arguments are correct.
+  Rather, they need to bring forward arguments which explain why something is bad for privacy and/or business—and then the Council evaluates their claims.
+  The objector is responsible for making a compelling case to help the Council understand their concerns, and should provide evidence and references to that end.</p>
+
+<p>An important role for the Team assignee is to anticipate questions the Council is likely to have about the Decision and the Objection during its
+  deliberations, and to work with the objector(s) and decider(s) to provide that information in the Team Report.</p>
+
+<p>Nevertheless, the Council should not dismiss an objection merely because the objector or the Team did not provide incontrovertible proof.
+  The Council is not judging a criminal case: there is no presumption of correctness in the original decision as there would be a presumption of
+  innocence in a criminal defendant; and the objector need not prove their claims beyond a reasonable doubt, but rather to <em>convince
+  the Council that, in the best interests of the Web, their objection should overturn the decision</em>.
+  Still, it is imprudent for objectors or deciders to count on the Council doing their homework for them, as insufficient documentation can lead
+  to the Council failing to see the point.</p>
+
+<p>The Council is responsible for fully understanding all sides of the argument and making an informed decision.
+  If the Council sees potential merit in the claims made on either side, but needs more information to be sure, it may investigate
+  (or ask the Team to investigate) until its members know enough to responsibly decide. During this thorough analysis, the Council may learn
+  new information, which might be brought to bear on the decision.
+  But that new information should be incidental to the analysis—the responsibility to make a convincing objection remains on the objectors.</p>
+
+<p>Placing the Burden of Convincing on the objectors is supported by several of the considerations above:</p>
+
+<ul>
+  <li><p>Speed. If the Council begins to look for additional new arguments, they are likely to take longer in their assessment.</p></li>
+  <li><p>Avoiding centralization. If every objection results in the Council accepting the Burden of Convincing on themselves, inevitably
+    it will cause more stakeholders to bring topics to the Council and ultimately begin to centralize decisions</p></li>
+  <li><p>Treating objectors consistently. If the Council begins to accept the Burden of Convincing on themselves for some objections,
+    then to be consistent, they will need to accept the burden for all objectors.
+    That would be a tremendous expansion of scope for Formal Objections.</p></li>
+  <li><p>Workload. If the Council begins to accept the Burden of Convincing on themselves, that would considerably add workload to the Council.</p></li>
+</ul>
+
+<h3 id="council-report">III. Council Reports</h3>
+<p>The Council Decision Report section of the Process covers what information the Council is expected to provide in its report. Fundamentally, the Council needs to either:</p>
+<ul>
+  <li><p>Cleanly overrule the objector and allow the Decision to stand.</p></li>
+  <li><p>Clearly sustain the objector and require those responsible to address the objection.</p></li>
+</ul>
+
+<p>
+  Overruling a Formal Objection does not imply that there is zero validity to the objection, only that the claims are insufficient to overturn this decision.
+  To the extent that there is some validity to the claims of the objectors, a Council decision to overrule the objectors does not give the Decider authority to
+  ignore these claims further in the development. It is therefore useful for the Council to distinguish between claims of the objector that they find to be
+  without merit, and those that are merely insufficient to justify overturning the decision but are nonetheless legitimate concerns that should be investigated
+  and potentially addressed later in the process.
+</p>
+
+<p>
+  When an objection is sustained, the Council can suggest an approach that it believes could repair the objection, but cannot make any dictates.
+  The Council is not in the business of writing charters or technical reports; sustaining an objection leaves the design of a new way forward to the responsible parties.
+</p>
+
+<p>
+  While providing guidance beyond a simple sustain/overrule decision increases the work load of the Council for an individual objection,
+  helping the community avoid predictable pitfalls reduces the amount of wasted effort both for the community and for future Councils.
+</p>
+
+<h2 id="best-practices"></h2>
+
+<p>
+  Above we described, qualitatively, how the Council should deal with objections. A useful Best Practices checklist may be arranged in categories.
+</p>
+
+<h3 id="thoroughness">I. Thoroughness</h3>
+
+<p>This includes:</p>
+
+<dl>
+  <dt>Understanding all sides of the argument</dt>
+  <dd><p>The Team assignee and W3C Council members should be fully comfortable they understand all sides of the argument.
+    In particular, the Team assignees should not begin their resolution efforts before hearing and understanding
+    the objections (whether or not they agree with them).
+    The W3C Council should not decide on the objection until each participant feels they understand all sides of the argument.</p></dd>
+  <dt>Consultation</dt>
+  <dd><p>The assignee and W3C Council should recognize that they have at their disposal any stakeholder who could reasonably inform the issue.
+    This includes Working Groups, Chairs, Members, Team, and the general public.
+    On technical issues the TAG might be particularly useful.</p></dd>
+  <dt>Attempt to find a consensus position</dt>
+  <dd><p>The assignee and Council should explore any potential paths to consensus that seem to have been overlooked.
+    When consensus is not possible (at all, or in a reasonable amount of time), the assignee should at least understand and clearly document why.</p></dd>
+  <dt>Analysis of all arguments raised</dt>
+  <dd><p>Although the W3C Council's published decision should be clear, well explained, and unambiguous, it should nonetheless acknowledge
+    good points raised by the party that is not favored in the ruling, but explain why they are not decisive.</p></dd>
+</dl>
+
+<h3 id="fairness">II. Fairness</h3>
+<p>This includes:</p>
+
+<dl>
+  <dt>Balance and depth</dt>
+  <dd><p>The Council will be fair to all parties not by attempting to excise all preconcieved opinions, but by bringing diverse, expert viewpoints
+    to the debate and weighing them responsibly.
+    The design of the Council therefore optimizes for the broadest engaged participation of its members, who represent the breadth and variety
+    of expertise in the W3C community.</p></dd>
+  <dt>Transparency</dt>
+  <dd><p>The assignee should inform all parties that potential resolution has been delegated to the assignee.
+    In this same spirit, if the issue is referred to the W3C Council for decision, all parties must be notified.
+    The report with the W3C Council's decision should include the names of the subset of the council that participated in that decision.</p></dd>
+  <dt>Adequate access</dt>
+  <dd><p>It is important for the assignee to offer all parties the opportunity to elaborate on their point of view.
+    For example, although the objection is already available in written form, the assignee should at least offer an opportunity
+    to the objector to have a 1:1 conversation.
+    All parties should be invited to key meetings where the assignee assesses whether a possible resolution proposal can gain consensus.
+    If a decision goes to the W3C Council, all participants should see the assignee's report before it goes to the W3C Council.</p></dd>
+  <dt>Respect for under-represented views</dt>
+  <dd><p>The assignee and W3C Council should recognize that often objections come from views of important web stakeholders whose views might be
+    under-represented where the decision is taken. Accordingly, the assignee and the W3C Council must be respectful of all views.</p></dd>
+  <dt>Gravitas</dt>
+  <dd><p>Notwithstanding “Respect for under-represented views”, the assignee and W3C Council should assign appropriate gravitas
+    to a Working Group decision that was made by the consensus of the WG and consistent with W3C Process.</p></dd>
+  <dt>Adherence to W3C Process</dt>
+  <dd><p>Occasionally formal objections arise when a decision was made which did not follow the “letter” of the W3C Process.
+    Such violations are quite serious and indeed could form a valid basis for a Formal Objection.
+    However, the W3C Council is not required to always sustain such an objection—they need to take all factors
+    into consideration in terms of the best solution for the web.</p></dd>
+</dl>
+
+<h3 id="communications">III. Communications</h3>
+
+<p>This includes:</p>
+
+<dl>
+  <dt>Publication of W3C Council decisions</dt>
+  <dd><p>W3C Council decisions form an important part of the public record; especially since they represent the most difficult areas in which
+    stakeholders could not reach consensus and the Team could not resolve the impasse.
+    Accordingly, it is important that W3C make available for the public record: the Team report, the W3C Council decision, and supporting
+    documentation which explain the rationale of the W3C Council decision.</p></dd>
+  <dt>Perception</dt>
+  <dd><p>The Council should clearly exhibit the qualities of fairness, transparency, and thoroughness described above.
+    Depending on the nature, publicity, and degree of controversy of the Formal Objection, special effort may
+    need to be made to explain how these best practices were achieved, e.g. to the public.</p></dd>
+  <dt>Ongoing communications</dt>
+  <dd><p>As the Formal Objection resolution process unfolds, all parties should be apprised of the status.
+    There should be no ambiguity about who is responsible for the current step or what that next step is
+    (e.g., the Team is writing a report, the Team is waiting for the Objector or Decider to respond to some question,
+    the Council is being convened, the Council is in deliberations, etc.). The Council Team Contact should ensure that
+    such communications take place and the process continues to move forward.</p></dd>
+</dl>
+
+
+<h3>Revision History</h3>
+<ul>
+<li>2023-03-30: Document created.</li>
+</ul>
+
+</div>
+<hr >
+
+<address><a href="https://www.w3.org/People/Lafon/">Yves Lafon</a> for
+<a href="https://www.w3.org/People/LeHegaret/">Philippe Le Hégaret</a>, guidebook editor<br>
+             <a href="mailto:plh@w3.org">plh@w3.org</a><br>
+      <a href="https://github.com/w3c/Guide">Yep, it's on GitHub</a>.
+</address>
+</body>
+</html>

--- a/council/council.html
+++ b/council/council.html
@@ -175,7 +175,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
   <li>
     <p>The W3C Council determines who will rule on this objection and who will chair the Council</p>
     <ul>
-      <li><p>See <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-participation"Council Participation, Dismissal, and Renunciation</a> and 
+      <li><p>See <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-participation">Council Participation, Dismissal, and Renunciation</a> and
         <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-chairing">Council Chairing</a>.</p></li>
       <li><p>Every person serving on the Council is expected to be sufficiently knowledgeable and thorough that they feel comfortable with the decision of the W3C Council.
         The breadth of the Council membership, and therefore the participation of each of its members, is key to the Council’s ability to provide an appropriate

--- a/council/council.html
+++ b/council/council.html
@@ -371,7 +371,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 
 <h3>Revision History</h3>
 <ul>
-<li>2023-03-30: Document created.</li>
+<li>2023-03-30: Document created from <a href="https://www.w3.org/2002/ab/">AB</a> draft.</li>
 </ul>
 
 </div>


### PR DESCRIPTION
This adds Council Guide, an HTML version of the AB markdown draft.
It should become live if/when the new Process containing Council is active