### PR TITLE
Update charter.html

### DIFF
--- a/process/charter.html
+++ b/process/charter.html
@@ -230,7 +230,7 @@ W3C Communications Team in the form of an extension announcement; see the
 <ul>
 <li>The "End Date" in the table at the top is modified in place.</li>
 <li>Any update to the Chair(s) (e.g., a Chair resigns or is (re)appointed), Staff Contact(s) (e.g., names, FTEs), etc.</li>
-<li>The changes including extension history are documented in the "About this charter" section at the bottom and lists each extension dates and the pairs of from/until dates. (Note: If the group is developing a new charter, link to the GitHub repo of where the new charter is being developed.</li>
+<li>The changes including extension history are documented in the "About this charter" section at the bottom and lists each extension dates and the pairs of from/until dates. (Note: If the group is developing a new charter, link to the GitHub repo of where the new charter is being developed).</li>
 <li>The text "Note: The group will document significant changes from this initial schedule on the group home page." is updated with a link to the group's updated milestones
 (e.g., on the group's site) to say something like "Note: See changes from this initial schedule on the group home page."</li>
 </ul>

--- a/process/charter.html
+++ b/process/charter.html
@@ -230,7 +230,7 @@ W3C Communications Team in the form of an extension announcement; see the
 <ul>
 <li>The "End Date" in the table at the top is modified in place.</li>
 <li>Any update to the Chair(s) (e.g., a Chair resigns or is (re)appointed), Staff Contact(s) (e.g., names, FTEs), etc.</li>
-<li>The changes including extension history are documented in the "About this charter" section at the bottom and lists each extension dates and the pairs of from/until dates.</li>
+<li>The changes including extension history are documented in the "About this charter" section at the bottom and lists each extension dates and the pairs of from/until dates. (Note: If the group is developing a new charter, link to the GitHub repo of where the new charter is being developed.</li>
 <li>The text "Note: The group will document significant changes from this initial schedule on the group home page." is updated with a link to the group's updated milestones
 (e.g., on the group's site) to say something like "Note: See changes from this initial schedule on the group home page."</li>
 </ul>


### PR DESCRIPTION
For charter extension, reflecting the [feedback](https://lists.w3.org/Archives/Member/w3c-ac-forum/2023AprJun/0104.html) about "the current charter History section should link to the GitHub version of where a new charter is developed ..."