### PR TITLE
Update guide to match Process 2023 having been adopted

### DIFF
--- a/council/council.html
+++ b/council/council.html
@@ -45,7 +45,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
     </div>
     
     <div id="Content">
-      <p>This document supplements the <span class="draft">[proposed]</span> Process Document by providing best practices to resolve and decide Formal Objections.</p>
+      <p>This document supplements the Process Document by providing best practices to resolve and decide Formal Objections.</p>
 
       <p>In this document, <dfn id="resolving">resolving</dfn> a Formal Objection means finding a solution that has no objections. <dfn id="deciding">Deciding</dfn> means 
         giving a yes/no answer to the question of whether an objection should be <dfn id="overrule">overruled</dfn> (i.e., no) or <dfn id="sustained">sustained</dfn> (i.e., yes).


### PR DESCRIPTION
Process 2023, which defines the Council, is no longer just proposed, and has been formally adopted.