### PR TITLE
Editorial and quality assurance on council.html

### DIFF
--- a/council/council.html
+++ b/council/council.html
@@ -53,7 +53,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 
 <h2 id="council"><a href="#council">Cases that warrant a Council</a></h2>
 
-  <p>W3C aims to make decisions by consensus. If there are differences of opinions, groups work hard to understand different points of view and reach agreement, 
+  <p>W3C aims to make decisions by consensus. If there are differences of opinions, groups work to understand different points of view and reach agreement, 
     either by compromise, or by the force of some argument. When that is working well, Formal Objections are rare, indeed.
   </p>
 
@@ -70,8 +70,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
     that require senior review. Some topics do not lend themselves to compromise, they are inherently yes/no decisions. It could be hard to find common ground.
   </p>
   
-  <p>Nonetheless, the fact that the process is oriented towards consensus implies that before an objection gets a senior review there already has been a great
-    deal of work on the issue. There is generally clarity on what the W3C decision was (that is being objected to). 
+  <p>Nonetheless, the fact that the process is oriented towards consensus implies that before an objection gets a senior review there already has been significan work on the issue. There is generally clarity on what the W3C decision was (that is being objected to). 
     The objector, in trying to reverse the decision, has generally pulled together their best arguments and brought them to the group. 
     The fact that so much work should be accomplished prior to senior review should make the effort to decide a Formal Objection easier.
   </p>
@@ -85,12 +84,12 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
   </p>
   <ol>
     <li id="case-1"><p>There is a Formal Objection to a decision in a Working Group.
-      The Team as a disinterested bystander attempts to resolve the objection.
+      The Team as a neutral bystander attempts to resolve the objection.
       If it succeeds, W3C takes the path recommended by the Team.
       If it fails, the Team prepares a report for the W3C Council.
       The W3C Council decides.</p></li>
     <li id="case-2"><p>The Team proposes a Charter to the W3C Advisory Committee and there are objections.
-      The Team attempts to resolve the objection even though they are not a disinterested bystander.
+      The Team attempts to resolve the objection even though they are not a neutral bystander.
       If it succeeds, W3C takes the recommended path.
       If it fails, the Team prepares a report for the W3C Council.
       The W3C Council decides.</p></li>
@@ -122,7 +121,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
   </p>
 
 <h3 id="team-fo"><a href="#team-fo">Team attempts to resolve Formal Objections</a></h3>
-  <p>When a Formal Objection is issued, the Team assigns someone to attempt to resolve the Formal Objection. 
+  <p>When a Formal Objection is raised, the Team assigns someone to attempt to resolve the Formal Objection. 
     That assignee is expected to follow the best practices below for this effort.
   </p>
 
@@ -167,7 +166,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
     <p>The report should be available for review by the relevant groups and objectors.</p>
     <ul>
       <li><p>If any participant feels that their viewpoint is not fairly represented, a limited time effort should be expended to get all relevant information into the document.</p></li>
-      <li><p>If at the end of the limited time effort the Team determines that it is not possible to get agreement on the summary document, then the Team publishes
+      <li><p>If at the end of the alloted time the Team determines that it is not possible to get agreement on the summary document, then the Team publishes
         their summary and notes which participants believe that it is not a fair summary. Those participants may write up their own viewpoints.</p></li>
         <li><p>The assignee should indicate an explicit team contact (which can be the assignee) for comments on the draft document.</p></li>
     </ul>
@@ -183,11 +182,11 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
     </ul>
   </li>
   <li>
-    <p>In extraordinary circumstances, the Council may vote to <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-delegation">delegate</a> or
+    <p>In exceptional circumstances, the Council may vote to <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-delegation">delegate</a> or
       <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-short-circuit">short-circuit</a> its decision.</p>
   </li>
   <li>
-    <p>The W3C Council <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-deliberations">deliberates and reaches a decision</a> to sustain or overrule the prior decision.</p>
+    <p>The W3C Council <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-deliberations">deliberates and reaches a decision</a> to sustain or overrule the original decision.</p>
     <ul>
       <li><p>If the W3C Council members deem that the written summaries are sufficient, they are not required to discuss with participants further, although they may
         do so if they wish. They may consult with deciders and objectors if they wish. See thoroughness and fairness below.</p></li>
@@ -213,7 +212,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
   <li><p>Assuring that objection processing does not become a means for all decisions to be centralized at W3C.</p></li>
   <li><p>Avoiding micromanagement.</p></li>
   <li><p>Treating all objectors consistently irrespective of who the objector might be.</p></li>
-  <li><p>Workload. If processing each Formal Objection results in a great deal of work for a very large Council, then
+  <li><p>Workload. If processing each Formal Objection results in significant work for a very large Council, then
     the Council will not have time to process the workload and the Council design will not scale.</p></li>
 </ul>
 
@@ -227,16 +226,16 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
   supported by all is always preferred. Nothing in this discussion precludes such an approach or forces an adversarial judicial proceeding.
   Nonetheless, there should be a clear expectation about the starting point for Council deliberations.</p>
 
-<p>Objectors should not be looking for the Council to come up with new arguments to support their point of view.
+<p>Objectors should not be looking at the Council to come up with new arguments to support their point of view.
   For example, if objectors have vague arguments of the form ”this is bad for privacy” or “this is bad for business”,
   they should not expect the Council to do the research to demonstrate whether their vague arguments are correct.
   Rather, they need to bring forward arguments which explain why something is bad for privacy and/or business—and then the Council evaluates their claims.
   The objector is responsible for making a compelling case to help the Council understand their concerns, and should provide evidence and references to that end.</p>
 
-<p>An important role for the Team assignee is to anticipate questions the Council is likely to have about the Decision and the Objection during its
-  deliberations, and to work with the objector(s) and decider(s) to provide that information in the Team Report.</p>
+<p>An important role for the Team assignee is to anticipate questions the Council is likely to have during its
+  deliberations about the Decision and the Objection, and to work with the objector(s) and decider(s) to provide that information in the Team Report.</p>
 
-<p>Nevertheless, the Council should not dismiss an objection merely because the objector or the Team did not provide incontrovertible proof.
+<p>Nevertheless, the Council should not dismiss an Objection merely because the objector or the Team did not provide incontrovertible proof.
   The Council is not judging a criminal case: there is no presumption of correctness in the original decision as there would be a presumption of
   innocence in a criminal defendant; and the objector need not prove their claims beyond a reasonable doubt, but rather to <em>convince
   the Council that, in the best interests of the Web, their objection should overturn the decision</em>.
@@ -246,7 +245,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 <p>The Council is responsible for fully understanding all sides of the argument and making an informed decision.
   If the Council sees potential merit in the claims made on either side, but needs more information to be sure, it may investigate
   (or ask the Team to investigate) until its members know enough to responsibly decide. During this thorough analysis, the Council may learn
-  new information, which might be brought to bear on the decision.
+  new information, which might bear on the decision.
   But that new information should be incidental to the analysis—the responsibility to make a convincing objection remains on the objectors.</p>
 
 <p>Placing the Burden of Convincing on the objectors is supported by several of the considerations above:</p>
@@ -255,7 +254,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
   <li><p>Speed. If the Council begins to look for additional new arguments, they are likely to take longer in their assessment.</p></li>
   <li><p>Avoiding centralization. If every objection results in the Council accepting the Burden of Convincing on themselves, inevitably
     it will cause more stakeholders to bring topics to the Council and ultimately begin to centralize decisions.</p></li>
-  <li><p>Treating objectors consistently. If the Council begins to accept the Burden of Convincing on themselves for some objections,
+  <li><p>Treating objectors consistently. If the Council begins to accept the Burden of Convincing on themselves for some Objections,
     then to be consistent, they will need to accept the burden for all objectors.
     That would be a tremendous expansion of scope for Formal Objections.</p></li>
   <li><p>Workload. If the Council begins to accept the Burden of Convincing on themselves, that would considerably add workload to the Council.</p></li>
@@ -264,32 +263,32 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 <h3 id="council-report"><a href="#council-report">III. Council Reports</a></h3>
 <p>The Council Decision Report section of the Process covers what information the Council is expected to provide in its report. Fundamentally, the Council needs to either:</p>
 <ul>
-  <li><p>Cleanly overrule the objector and allow the Decision to stand.</p></li>
-  <li><p>Clearly sustain the objector and require those responsible to address the objection.</p></li>
+  <li><p>Cleanly overrule the Objection and allow the Decision to stand.</p></li>
+  <li><p>Clearly sustain the Objection and require the responsible parties to address the objection.</p></li>
 </ul>
 
 <p>
-  Overruling a Formal Objection does not imply that there is zero validity to the objection, only that the claims are insufficient to overturn this decision.
-  To the extent that there is some validity to the claims of the objectors, a Council decision to overrule the objectors does not give the Decider authority to
+  Overruling a Formal Objection does not imply that there is zero validity to the Objection, only that the claims are insufficient to overturn this decision.
+  To the extent that there is some validity to the claims of the objectors, a Council decision to overrule the Objection does not give the Decider authority to
   ignore these claims further in the development. It is therefore useful for the Council to distinguish between claims of the objector that they find to be
   without merit, and those that are merely insufficient to justify overturning the decision but are nonetheless legitimate concerns that should be investigated
   and potentially addressed later in the process.
 </p>
 
 <p>
-  When an objection is sustained, the Council can suggest an approach that it believes could repair the objection, but cannot make any dictates.
-  The Council is not in the business of writing charters or technical reports; sustaining an objection leaves the design of a new way forward to the responsible parties.
+  When an Objection is sustained, the Council can suggest an approach that it believes could repair the Objection, but cannot make any dictates.
+  The Council is not in the business of writing charters or technical reports; sustaining an Objection leaves the design of a new way forward to the responsible parties.
 </p>
 
 <p>
-  While providing guidance beyond a simple sustain/overrule decision increases the workload of the Council for an individual objection,
+  While providing guidance beyond a simple sustain/overrule decision increases the workload of the Council for an individual Objection,
   helping the community avoid predictable pitfalls reduces the amount of wasted effort both for the community and for future Councils.
 </p>
 
 <h2 id="best-practices"><a href="#best-practices"></a></h2>
 
 <p>
-  Above we described, qualitatively, how the Council should deal with objections. A useful Best Practices checklist may be arranged in categories.
+  Above we described, qualitatively, how the Council should deal with Objections. A useful Best Practices checklist may be arranged in categories.
 </p>
 
 <h3 id="thoroughness"><a href="#thoroughness">I. Thoroughness</a></h3>
@@ -300,8 +299,8 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
   <dt>Understanding all sides of the argument</dt>
   <dd><p>The Team assignee and W3C Council members should be fully comfortable that they understand all sides of the argument.
     In particular, the Team assignees should not begin their resolution efforts before hearing and understanding
-    the objections (whether or not they agree with them).
-    The W3C Council should not decide on the objection until each participant feels they understand all sides of the argument.</p></dd>
+    the Objections (whether or not they agree with them).
+    The W3C Council should not decide on the Objection until each participant feels they understand all sides of the argument.</p></dd>
   <dt>Consultation</dt>
   <dd><p>The assignee and W3C Council should recognize that they have at their disposal any stakeholder who could reasonably inform the issue.
     This includes Working Groups, Chairs, Members, Team, and the general public.
@@ -311,7 +310,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
     When consensus is not possible (at all, or in a reasonable amount of time), the assignee should at least understand and clearly document why.</p></dd>
   <dt>Analysis of all arguments raised</dt>
   <dd><p>Although the W3C Council's published decision should be clear, well explained, and unambiguous, it should nonetheless acknowledge
-    good points raised by the party that is not favored in the ruling, but explain why they are not decisive.</p></dd>
+    legitimate points raised by the party that is not favored in the ruling, but explain why they are not decisive.</p></dd>
 </dl>
 
 <h3 id="fairness"><a href="#fairness">II. Fairness</a></h3>
@@ -329,16 +328,16 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
     The report with the W3C Council's decision should include the names of the subset of the council that participated in that decision.</p></dd>
   <dt>Adequate access</dt>
   <dd><p>It is important for the assignee to offer all parties the opportunity to elaborate on their point of view.
-    For example, although the objection is already available in written form, the assignee should at least offer an opportunity
+    For example, although the Objection is already available in written form, the assignee should at least offer an opportunity
     to the objector to have a 1:1 conversation.
     All parties should be invited to key meetings where the assignee assesses whether a possible resolution proposal can gain consensus.
     If a decision goes to the W3C Council, all participants should see the assignee's report before it goes to the W3C Council.</p></dd>
-  <dt>Respect for under-represented views</dt>
-  <dd><p>The assignee and W3C Council should recognize that often objections come from views of important web stakeholders whose views might be
-    under-represented where the decision is taken. Accordingly, the assignee and the W3C Council must be respectful of all views.</p></dd>
+  <dt>Consideration of under-represented views</dt>
+  <dd><p>The assignee and W3C Council should recognize that often Objections come from views of important Web stakeholders whose views might be
+    under-represented where the decision is taken. Accordingly, the assignee and the W3C Council must consider all views.</p></dd>
   <dt>Gravitas</dt>
-  <dd><p>Notwithstanding “Respect for under-represented views”, the assignee and W3C Council should assign appropriate gravitas
-    to a Working Group decision that was made by the consensus of the WG and consistent with W3C Process.</p></dd>
+  <dd><p>Notwithstanding “Consideration of under-represented views”, the assignee and W3C Council should assign appropriate gravitas
+    to a Working Group decision that was made by the consensus of the group and consistent with W3C Process.</p></dd>
   <dt>Adherence to W3C Process</dt>
   <dd><p>Occasionally Formal Objections arise when a decision was made which did not follow the “letter” of the W3C Process.
     Such violations are quite serious and indeed could form a valid basis for a Formal Objection.
@@ -356,7 +355,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
     stakeholders could not reach consensus and the Team could not resolve the impasse.
     Accordingly, it is important that W3C make available for the public record: the Team report, the W3C Council decision, and supporting
     documentation which explain the rationale of the W3C Council decision.
-    (See <a href="https://www.w3.org/about/council/">W3C Council public records</a>)</p></dd>
+    (See <a href="https://www.w3.org/about/council/">W3C Council public records</a>.)</p></dd>
   <dt>Perception</dt>
   <dd><p>The Council should clearly exhibit the qualities of fairness, transparency, and thoroughness described above.
     Depending on the nature, publicity, and degree of controversy of the Formal Objection, special effort may

--- a/council/council.html
+++ b/council/council.html
@@ -70,7 +70,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
     that require senior review. Some topics do not lend themselves to compromise, they are inherently yes/no decisions. It could be hard to find common ground.
   </p>
   
-  <p>Nonetheless, the fact that the process is oriented towards consensus implies that before an objection gets a senior review there already has been significan work on the issue. There is generally clarity on what the W3C decision was (that is being objected to). 
+  <p>Nonetheless, the fact that the process is oriented towards consensus implies that before an objection gets a senior review there already has been significant work on the issue. There is generally clarity on what the W3C decision was (that is being objected to). 
     The objector, in trying to reverse the decision, has generally pulled together their best arguments and brought them to the group. 
     The fact that so much work should be accomplished prior to senior review should make the effort to decide a Formal Objection easier.
   </p>

--- a/council/council.html
+++ b/council/council.html
@@ -182,7 +182,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
     </ul>
   </li>
   <li>
-    <p>In exceptional circumstances, the Council may vote to <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-delegation">delegate</a> or
+    <p>In extraordinary circumstances, the Council may vote to <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-delegation">delegate</a> or
       <a class="TODO" href="https://www.w3.org/Consortium/Process/Drafts/#council-short-circuit">short-circuit</a> its decision.</p>
   </li>
   <li>


### PR DESCRIPTION
... including re-using terminology from the Process Document where relevant to avoid mis-interpretation.