### PR TITLE
Moved adv-notice into the Guidebook

### DIFF
--- a/process/adv-notice.html
+++ b/process/adv-notice.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" >
+<title>How to send advance notice of work to the Advisory Committee</title>
+<link rel="stylesheet" type="text/css" href="../assets/main.css">
+<!-- Originally at https://www.w3.org/2005/09/adv-notice.html -->
+</head>
+<body>
+<a href=".." title="W3C Home"><img src="/Icons/WWW/w3c_home" alt=
+"W3C" border="0" /></a> . <a href="/Guide/">Art of Consensus Guide</a>
+
+<h1>How to send advance notice of work to the Advisory Committee</h1>
+
+<p>This document describes the <a href="https://www.w3.org/staff/strat/">Strategy
+Team</a>'s <a href="#policy">implementation</a> of
+the <a href="https://www.w3.org/Consortium/Process/#WGCharterDevelopment">Process
+Document requirements</a> related to advance notice to the Advisory
+Committee of charters in development. See the
+<a href="#bg">background</a> for the advance notice policy and
+this document.</p>
+
+<h2 id="policy">Sending advance notice to the Advisory Committee</h2>
+
+<dl>
+<dt>Who/Where</dt>
+<dd>
+<p>The <a href="https://www.w3.org/staff/strat/">Strategy team</a> determines when
+to inform the AC of work-in-progress. These announcements are sent by <a href="https://www.w3.org/staff/comm/">MarComm</a>
+to w3c-ac-members@w3.org and cc:
+  chairs@w3.org.</p>
+<p>As of May 2014, unless an advance notice strongly requires
+Member-only confidentiality (which should be rare), we also inform the
+public
+via <a href="https://lists.w3.org/Archives/Public/public-new-work/">public-new-work@w3.org</a>;
+see <a href="https://lists.w3.org/Archives/Public/public-new-work/2022Mar/0012.html">example</a>. This
+is done by MarComm.</p>
+</dd>
+
+<dt>When</dt>
+<dd>
+<p>Specialists, in conjunction with the Strategy Lead, make this
+decision based on early assessment of the factors in
+"<a href='https://github.com/w3c/strategy/blob/master/3.Evaluation.md'>Evaluation</a>"[3]
+as well as considering when it is useful to encourage broader input to
+discussion. In the Process-required notice to the AC, the Strategy
+team will give an early status report on the work and likely timeline
+for further progress (from information captured in the Funnel).</p>
+<p>Advance notice is not an indication that work *will* necessarily be
+sent for charter review, but an indication that the Team is seriously
+evaluating possible work, and seeks wider feedback.
+</p>
+</dd>
+
+<dt>What</dt>
+<dd>
+<p>There is
+a <a href="https://www.w3.org/new-doc-from-template?location=%2FTeam%2F&amp;template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fadv-charter.html&amp;submit=Continue...">template
+for advance notice</a>. Please look for recent examples in
+the <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/">w3c-ac-members
+archive</a>.</p>
+
+<p>The advance notice announcement to the Membership MUST include this
+information:</p>
+
+<ul>
+<li>A summary of the intended work</li>
+<li>A statement welcoming the Members to 
+use w3c-ac-forum for general expressions
+of interest and support. </li>
+<li>A request that Members send substantive comments and engage
+on substantive discussion on a different mailing list or github repository
+(i.e., <strong>other than w3c-ac-forum</strong>).</li>
+<li>If applicable, a statement that the archive of this second list
+is Member-visible.</li>
+<li>Contact information if people have questions; generally these will
+be the names of one or more people on the Team.</li>
+</ul>
+
+<p>The advance notice announcement to the Membership SHOULD include this
+information:</p>
+
+<ul>
+<li>Expectations about when a formal Advisory Commitee Review will begin.</li>
+</ul>
+
+<p>The advance notice announcement to the Membership MAY include this
+information:</p>
+
+<ul>
+<li>Pointers to draft materials. In other words, the announcement is
+not required to include a draft charter, but if one is available,
+please do send it to the AC.</li>
+<li>Information about other mailing lists for comments, as the
+situation requires.</li>
+</ul>
+</dd>
+</dl>
+
+<h2 id="bg">Background for this document</h2>
+
+<p>The <a href="https://www.w3.org/Consortium/Process/#WGCharterDevelopment">Process Document requirements</a> for
+advance notice were introduced in response to requests from Members to
+be more in the loop earlier for work in development. These
+requirements were added to provide additional transparency to 
+some work carried out (in general) by the Team, 
+to encourage Members to show support for work
+in development early (on w3c-ac-forum), and to enable those interested in
+shaping a charter to participate on a separate list (so as not to
+flood w3c-ac-forum).</p>
+
+<p>Hence the sentence in the Process Document: "Advisory Committee
+representatives MAY express their general support on the Advisory
+Committee discussion list."</p>
+
+<p>These ideas are further discussed in <cite><a
+href="http://www.w3.org/2002/05/rec-tips">Tips for Getting to
+Recommendation Faster</a></cite>, in particular:</p>
+
+<blockquote>
+
+<p>Start as early as Group charter development time, by garnering support from
+fellow W3C Members on w3c-ac-forum. When there is substantial support
+for new work among the Members, the Team may create a special mailing
+list for discussion among Members and Team about Group charter development.</p>
+</blockquote>
+
+<p>The Process Document requirements, excerpted here, are:</p>
+
+<blockquote>
+<p>The Team MUST notify the Advisory Committee when a charter for a
+new Working Group or Interest Group is in development. This is
+intended to raise awareness, even if no formal proposal is yet
+available. Advisory Committee representatives MAY provide feedback on
+the Advisory Committee discussion list or via other designated
+channels.</p>
+<p>W3C MAY begin work on a Working Group or Interest Group charter at
+any time.</p>
+<p style="text-align:
+right">-- <cite><a href="https://www.w3.org/Consortium/Process/#WGCharterDevelopment">Process
+Document, section 4.1 "Initiating Charter Development"</a></cite></p>
+</blockquote>
+
+<hr title="address separator" />
+<p>Questions? <a href="mailto:plh@w3.org">plh@w3.org</a></address>
+</body>
+</html>

--- a/process/adv-notice.html
+++ b/process/adv-notice.html
@@ -3,14 +3,24 @@
 <head>
 <meta charset="utf-8" >
 <title>How to send advance notice of work to the Advisory Committee</title>
-<link rel="stylesheet" type="text/css" href="../assets/main.css">
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/generic-base-1.css" type="text/css">
+<link rel="stylesheet" type="text/css" href="https://www.w3.org/Guide/guide2006.css">
+<link rel="shortcut icon" href="https://www.w3.org/Icons/WWW/Literature.gif">
+<link rel="start" title="Guidebook for W3C Collaborators" href="https://www.w3.org/Guide/">
+<link rel="copyright" title="Copyright" href="https://www.w3.org/Consortium/Legal/2002/ipr-notice-20021231#Copyright">
 <!-- Originally at https://www.w3.org/2005/09/adv-notice.html -->
 </head>
 <body>
-<a href=".." title="W3C Home"><img src="/Icons/WWW/w3c_home" alt=
-"W3C" border="0" /></a> . <a href="/Guide/">Art of Consensus Guide</a>
-
-<h1>How to send advance notice of work to the Advisory Committee</h1>
+  <div id="header">
+    <span class="logo">
+      <a href="/">
+        <img src="https://www.w3.org/Icons/WWW/w3c_home_nb" alt="W3C" height="48" width="72">
+      </a>
+    </span>
+    <div class="breadcrumb"><a href="https://www.w3.org/get-involved/">Get involved</a> → <a href="https://www.w3.org/Guide/">The Art of Consensus</a> →
+<h1>How to send advance notice of work<br>to the Advisory Committee</h1></div>
+    <p class="baseline">This <strong>Guidebook</strong> is the collected wisdom of the W3C Group Chairs and other collaborators.</p>
+  </div>
 
 <p>This document describes the <a href="https://www.w3.org/staff/strat/">Strategy
 Team</a>'s <a href="#policy">implementation</a> of
@@ -65,7 +75,7 @@ information:</p>
 
 <ul>
 <li>A summary of the intended work</li>
-<li>A statement welcoming the Members to 
+<li>A statement welcoming the Members to
 use w3c-ac-forum for general expressions
 of interest and support. </li>
 <li>A request that Members send substantive comments and engage
@@ -102,8 +112,8 @@ situation requires.</li>
 <p>The <a href="https://www.w3.org/Consortium/Process/#WGCharterDevelopment">Process Document requirements</a> for
 advance notice were introduced in response to requests from Members to
 be more in the loop earlier for work in development. These
-requirements were added to provide additional transparency to 
-some work carried out (in general) by the Team, 
+requirements were added to provide additional transparency to
+some work carried out (in general) by the Team,
 to encourage Members to show support for work
 in development early (on w3c-ac-forum), and to enable those interested in
 shaping a charter to participate on a separate list (so as not to
@@ -142,6 +152,7 @@ Document, section 4.1 "Initiating Charter Development"</a></cite></p>
 </blockquote>
 
 <hr title="address separator" />
-<p>Questions? <a href="mailto:plh@w3.org">plh@w3.org</a></address>
+<p>Feedback is to <a href="https://github.com/orgs/w3c/teams/guidebook">@w3c/guidebook</a>
+  is welcome on <a href="https://github.com/w3c/Guide/issues">GitHub</a></p>
 </body>
 </html>

--- a/process/charter.html
+++ b/process/charter.html
@@ -54,7 +54,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 <ul>
 
 <li>
-<a href="/2005/09/adv-notice.html">Advance Notice</a>
+<a href="adv-notice.html">Advance Notice</a>
 </li>
 
 <li>
@@ -87,7 +87,7 @@ Call for Participation Template</a></li>
 <li><a
 href="https://www.w3.org/Consortium/Process/#GAGeneral">Process
 Document on Groups</a></li>
-	<li><a href="/2005/09/adv-notice.html">How to
+	<li><a href="adv-notice.html">How to
 Send Advance Notice of Work to the Advisory Commitee</a></li>
 <li><a href="/2003/04/closing-group.html">How to Close a
 Group</a></li>
@@ -148,7 +148,7 @@ charter to charter. In practice, if the advance notice would precede
 the formal call for review by only a short delay, we skip the advance
 notice.</p>
 
-<p>The Team should consult <a href="/2005/09/adv-notice.html">How to
+<p>The Team should consult <a href="adv-notice.html">How to
 Send Advance Notice of Work to the Advisory Committee</a> for more
 information and a template announcement.</p>
 


### PR DESCRIPTION
Replaces https://www.w3.org/2005/09/adv-notice.html

* No need to notify w3m when an advance notice is sent. That should be handle by [TiLT](https://www.w3.org/Guide/teamcontact/tilt.html#communication)
* Removed the note about chairs nomination. Again, that should be handled by TiLT. (ie TiLT should block if the information about the chairs is insufficient).
