### PR TITLE
TiLT Evaluation of AC results

### DIFF
--- a/process/tilt/index.html
+++ b/process/tilt/index.html
@@ -31,6 +31,16 @@
         </ul>
       </div>
 
+      <div class="toolbox box" style="margin-bottom: 1em">
+        <h4>Related Resources</h4>
+        <ul>
+            <li><a
+                href="../charter.html">How to Create a Working Group or Interest Group</a></li>
+            <li><a
+                href="post-ac-review.html">TilT Evaluation of the AC Review Results</a></li>
+            </ul>
+        </div>
+
 <p>The mission of the TiLT is to make technical team decisions described in the W3C Process.</p>
 
 <p>TiLT authority comes from <a href="https://www.w3.org/Consortium/Process/#Team">delegation

--- a/process/tilt/post-ac-review.html
+++ b/process/tilt/post-ac-review.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html  lang="en">
+<head>
+<meta charset="utf-8">
+<title>TilT Evaluation of the AC Review Results</title>
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/generic-base-1.css" type="text/css">
+<link rel="stylesheet" type="text/css" href="https://www.w3.org/Guide/guide2006.css">
+<link rel="shortcut icon" href="https://www.w3.org/Icons/WWW/Literature.gif">
+<link rel="start" title="Guidebook for W3C Collaborators" href="https://www.w3.org/Guide/">
+<link rel="copyright" title="Copyright" href="https://www.w3.org/Consortium/Legal/2002/ipr-notice-20021231#Copyright">
+</head>
+<body>
+    <div id="header">
+        <span class="logo">
+          <a href="/">
+            <img src="https://www.w3.org/Icons/WWW/w3c_home_nb" alt="W3C" height="48" width="72">
+          </a>
+        </span>
+        <div class="breadcrumb"><a href="https://www.w3.org/participate/">Participate</a> → <a href="https://www.w3.org/Guide/">The Art of Consensus</a> → 
+  <h1>TilT Evaluation of the AC Review Results</h1></div>
+        <p class="baseline">This <strong>Guidebook</strong> is the collected wisdom of the W3C Group Chairs and other collaborators.</p>
+      </div>
+
+      <div class="toolbox box" style="margin-bottom: 1em">
+        <h4>Related Resources</h4>
+        <ul>
+            <li><a
+                href="../charter.html">How to Create a Working Group or Interest Group</a></li>
+            <li><a
+                href="./">Technical issues Lead Team</a></li>
+            </ul>
+        </div>
+
+<h2 id="review-eval">TilT Evaluation of the 
+    AC Review Results</h2>
+
+<p>How TiLT manages AC review results depends on the results
+themselves.  The first three cases below require TilT discussion; the
+fourth only requires notification to TiLT.</p>
+
+<h3>Case 1: There are Unresolved Formal Objections</h3>
+
+<p>The charter shepherd <a href="#TiLT-report">reports</a> the review
+  results to TiLT for discussion and <a
+  href='https://github.com/w3c/tilt-private/issues/new/choose'>requests the start
+  of a Council</a>.</p>
+
+<h3>Case 2: There are Changes</h3>
+
+<p>If there are no unresolved Formal Objections but there are changes
+to the charter &mdash;either requested by reviewers or resulting from
+resolution of Formal Objections:</p>
+
+<ul>
+  <li>The charter shepherd changes the charter and notifies all
+    of the AC Reps who replied to the call for review. These AC Reps have
+    7-10 days to express dissent.</li>
+  <li>In parallel or subsequently, the charter shepherd also
+    <a href="#TiLT-report">reports</a> the review results to TiLT. That message
+    should highlight the same (7-10 day) window for TiLT to request discussion
+    of the changes.</li>
+</ul>
+
+<p>If the time period elapses without dissent by AC Reps and TiLT gave its
+  <a href="./#timing">approval</a>,
+  the charter shepherd proceeds directly to 
+<a href="../charter.html#director-decision">requesting
+  announcement of the charter</a>. Otherwise, TiLT discussion takes
+place. Upon subsequent approval, the charter shepherd
+<a href="../charter.html#director-decision">requests announcement</a>.</p>
+
+<h3>Case 3: Uncontroversial Review but TiLT Approval Required</h3>
+
+<p>If there are no Formal Objections and no changes, then there are
+  still two scenarios when TiLT approval is required:</p>
+
+<ul>
+  <li>In the TiLT decision to request AC review, there was
+      a requirement to discuss the AC review results whatever the outcome
+      (e.g., to assign FTE based on the level Member support).</li>
+  <li>The review did not reach the 5% threshold and TiLT did not
+    relax that requirement in the decision to seek AC review.</li>
+</ul>
+
+<p>In either case, the charter shepherd <a href="#TiLT-report">reports</a>
+  the review results. That message should highlight that the review was
+  uncontroversial and point out which topics now require TiLT
+  approval. Upon subsequent approval, the charter shepherd
+<a href="../charter.html#director-decision">requests announcement of the charter</a>.</p>
+
+<h3>Case 4: Uncontroversial Review and No TiLT Approval Required</h3>
+
+<p>The charter shepherd <a href="#TiLT-report">reports</a> the review
+  results to TiLT and indicates that the charter is deemed approved and
+  no further TiLT approval is required.</p>
+
+<p>The charter shepherd then
+  <a href="../charter.html#director-decision">requests announcement of the charter</a>.</p>
+
+<h3 id="TiLT-report">Reporting AC Review Results to TiLT</h3>
+
+<p>In all of the above cases, the charter shepherd reports the review
+outcomes to <a
+href='https://github.com/w3c/tilt-private/issues/new/choose'>TiLT</a> with the
+following information:</p>
+
+<ul>
+<li>The distribution of reviews. It helps to highlight either that there have been
+  Formal Objections or that there is Consensus.</li>
+
+<li>A record of any substantial review comments and replies to those comments. In particular, for any Formal Objection, whether:
+  <ul>
+    <li>No attempt has been made to resolve it.</li>
+    <li>An attempt has been made to resolve it but it has remained unresolved
+      (e.g., because the reviewer did not respond, or no agreement can be reached).</li>
+    <li>It has been resolved. In this case indicate the resolution and whether
+      that involved changes to the charter.</li>
+    <li>It has been overridden by the Director (e.g, deemed out of scope or
+      overruled for any other reason).</li>
+  </ul>
+</li>
+
+<li>A list of proposed changes to the charter (such as a link to one or more pull requests),
+  and whether those changes were requested during the review or as a result of resolving
+  a Formal Objection.</li>
+
+<li>Pertinent IPR statements, if any</li>
+</ul>
+
+<hr>
+<p>Feedback is to <a href="https://github.com/orgs/w3c/teams/tilt">@w3c/tilt</a> and
+    is welcome on <a href="https://github.com/w3c/Guide/issues">GitHub</a></p>
+</body>
+</html>


### PR DESCRIPTION
This is a refinement on how TiLT operates when dealing with AC results.

This adopts the [previous mode of operation](https://www.w3.org/Project/Brief/CharterApproval.html#review-eval) from W3M.

It basically allows a straightofrward AC Review results (proper level of support, no changes) to simply inform TiLT and have no need for TiLT to move to next step.