### PR TITLE
There's no more latest guidance from the Director, just TiLT.

### DIFF
--- a/process/charter.html
+++ b/process/charter.html
@@ -113,7 +113,7 @@ Getting to Recommendation Faster</a></li>
 
 	<p>Keep the Project Management Lead (for existing groups) and/or the Strategy Lead (for new groups) in the loop.</p>
 
-  <p id="'TiLT">TiLT, the <a href='./tilt/'>W3C Technical issues Lead Team</a>, is in charge of
+  <p id="TiLT">TiLT, the <a href='./tilt/'>W3C Technical issues Lead Team</a>, is in charge of
     the technical decisions described in the W3C Process,
     decided or determined by the Team (<a
     href="https://www.w3.org/Consortium/Process/Drafts/#decision-types">Types
@@ -130,7 +130,7 @@ should send them to the Team Contact, who should see that the
 request is reviewed by the Project and Strategy Leads in a timely manner.</p>
 
 <p>Team Contacts and others proposing charters should start from the <a href="https://w3c.github.io/charter-drafts/">Charter Template</a>, rather than copying
-	an existing Group charter, as the template reflects the latest guidance from Membership and the Director/TiLT on common matters of structure.</p>
+	an existing Group charter, as the template reflects the latest guidance from Membership and <a href="./tilt/">TiLT</a> on common matters of structure.</p>
 
 
 <!--<p class=timeline><em>Timeline:</em> For existing groups, this takes no time. For new groups, it may take one month or more for W3M


### PR DESCRIPTION
I also fixed an anchor for 'TiLT (extra apostrophe).

I think this is right?