### PR TITLE
Remove link to outdated info

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,8 +281,6 @@
             Benefits</a> </li>
         <li>Patent Policy Information about Groups and Disclosures can be
           found from the <a href="https://www.w3.org/groups/">Group pages</a></li>
-        <li><a href="https://www.w3.org/2004/08/25-chairs-pp.html">What's in it
-            for Chairs?</a></li>
         <li>...more questions? Contact the <a href="https://www.w3.org/2004/pp/psig/"><abbr title="W3C Patents and Standards Interest Group">PSIG</abbr></a></li>
       </ul>
       <h4 id="testsuites">Test Suites</h4>


### PR DESCRIPTION
The link was to a 2004 document written when the idea of a patent policy was still fairly new.