### PR TITLE
Move the editors pages into the Guidebook

### DIFF
--- a/editor/editors-draft.html
+++ b/editor/editors-draft.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+    <title>Style for Group-internal Drafts</title>
+    <link rel="stylesheet" href="https://www.w3.org/StyleSheets/generic-base-1.css" type="text/css">
+    <link rel="stylesheet" type="text/css" href="https://www.w3.org/Guide/guide2006.css">
+    <link rel="shortcut icon" href="https://www.w3.org/Icons/WWW/Literature.gif">
+  </head>
+  <body>
+    <div id="header">
+      <span class="logo">
+        <a href="/">
+          <img src="https://www.w3.org/Icons/WWW/w3c_home_nb" alt="W3C" height="48" width="72">
+        </a>
+      </span>
+      <div class="breadcrumb"><a href="https://www.w3.org/participate/">Participate</a> → <a href="https://www.w3.org/Guide/">The Art of Consensus</a> → 
+<h1>Style for Group-internal Drafts</h1></div>
+      <p class="baseline">This <strong>Guidebook</strong> is the collected wisdom of the W3C Group Chairs and other collaborators.</p>
+    </div>
+<div class="toc">
+ <h4>Also On This Page &#x2192;</h4>
+ <ul>
+   <li style="display: none"><a href="#sotd">Status</a>  &bull;</li>
+   <li><a href="#intro">Intro</a>  &bull;</li>
+   <li><a href="#reqs">Requirements</a>  &bull;</li>
+   <li><a href="#guidelines">Guidelines</a>  &bull;</li>
+   <li><a href="#faq">FAQ</a></li>
+ </ul>
+</div>
+
+<div class="toolbox box" style="margin-bottom: 1em"> 
+<h4>Publication Policies</h4>
+<ul>
+  <li><a href="/pubrules">Technical Report Publication Policy</a></li>
+
+  <li><a href="/pubrules/doct">About pubrules</a></li>
+  <li><a href="/2005/05/tr-versions">Version Management in W3C Technical Reports</a></li>
+  <li><a href="/2005/07/13-pubrules-disclosure">Guidelines for linking to
+  disclosure pages</a></li>
+  <li><a href="/2005/07/13-nsuri">URIs for W3C Namespaces</a></li>
+  <li><a href="/2002/06/registering-mediatype2014">How to Register a Media Type for a W3C Specification</a></li>
+  <li><a href="/2005/04/xpointer-policy">XPointer Scheme Name Registry Policy</a></li>
+</ul>
+<h4>Resources</h4>
+<ul>
+  <li><a href="../transitions">Organize Recommendation Track
+  Transition</a></li>
+  <li><a
+	  href="https://www.w3.org/Consortium/Process/#Reports">Recommendation
+  Track Process</a></li>
+  <li><a href=".">W3C Editors' Home Page</a></li>
+  <li><a href="../manual-of-style/">Manual of Style</a></li>
+  <li>Style Guidelines for Group-Internal Drafts</li>
+</ul>
+<h4>Tools</h4>
+<ul>
+  <li><a href="http://validator.w3.org/checklink">Link checker</a></li>
+  <li><a href="http://validator.w3.org/">HTML Validator</a></li>
+  <li><a href="http://jigsaw.w3.org/css-validator/">CSS Validator</a></li>
+</ul>
+</div>
+
+<h2 id="sotd">Status of this Document</h2>
+
+<p>This document, for W3C groups, reflects some discussion within the
+Team about how groups can avoid confusion between their internal
+publications and formal W3C Technical Reports.</p>
+
+<h2 id="intro">Introduction</h2>
+
+<p>Many Working Groups publish drafts for internal group review
+between publications on the TR page. In the interest of clarity of the W3C process, we request that
+Working Groups take care that documents are labeled with their true
+status. Sometimes labels like "W3C Working Draft" are copied from
+documents that are truly a product of the W3C Working Draft process to
+documents that are not, or at least not yet.
+</p>
+
+<p>The guidelines below are intended to reduce confusion between
+group-internal drafts (some of which are Member-only, while others are public) and
+published documents that have been through additional W3C processes.
+Documents that follow these guidelines have no formal standing within
+W3C.</p>
+
+<h2 id="reqs">Requirements for Group-Internal Drafts</h2>
+
+<ul>
+<li>In a Working Group, group-internal drafts MUST follow 
+the licensing as defined in its charter.</li>
+</ul>
+
+<h2 id="guidelines">Guidelines for Group-Internal Drafts</h2>
+
+<ol>
+<li>Use this style sheet:  <code>https://www.w3.org/StyleSheets/TR/2021/W3C-ED.css</code></li>
+<li>Use an appropriate label for the document, as in:
+<pre>
+ &lt;h1&gt;Architecture of the World Wide Web, 
+           Volume One&lt;/h1&gt;
+ &lt;h2&gt;Editor's Draft 15 December 2004&lt;/h2&gt;
+</pre>
+</li>
+<li>When the document is "Member-confidential", indicate
+this in an obvious place
+at the top of the document. Please also include a reminder 
+in the status section.
+</li>
+<li>Set expectations about the stability and level of confidentiality of the document in the status section, for example:
+<blockquote>
+We welcome feedback on this informal collection of resources, 
+which is subject to change without notice.
+</blockquote>
+</li>
+</ol>
+
+<h2 id="faq">Frequently Asked Questions (FAQs)</h2>
+
+<h3>1. Can our group publish this type of document elsewhere than w3.org?</h3>
+
+
+<p>In general, no (but see <a href="https://github.com/w3c/modern-tooling/issues/110">Issue #110</a>). Please avoid giving the impression that these drafts have formal status within W3C or another body. Please do not label them "W3C Working Draft" in these documents.</p>
+
+<p>If you are just attaching a copy of an in-progress draft in email
+in preparation for a group teleconference, keep in mind that the
+attachment is archived and may be found by readers who don't have that
+context. Please erase any indication that this is a W3C Working Draft.</p>
+
+<hr>
+<p>Feedback is to <a href="https://github.com/orgs/w3c/teams/tilt">@w3c/tilt</a>
+   and is welcome on <a href="https://github.com/w3c/Guide/issues">GitHub</a></p>
+</address>
+</body>
+</html>

--- a/editor/index.html
+++ b/editor/index.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+    <title>W3C Editors' Home Page</title>
+    <link rel="stylesheet" href="https://www.w3.org/StyleSheets/generic-base-1.css" type="text/css">
+    <link rel="stylesheet" type="text/css" href="https://www.w3.org/Guide/guide2006.css">
+    <link rel="shortcut icon" href="https://www.w3.org/Icons/WWW/Literature.gif">
+  </head>
+  <body>
+    <div id="header">
+      <span class="logo">
+        <a href="/">
+          <img src="https://www.w3.org/Icons/WWW/w3c_home_nb" alt="W3C" height="48" width="72">
+        </a>
+      </span>
+      <div class="breadcrumb"><a href="https://www.w3.org/participate/">Participate</a> → <a href="https://www.w3.org/Guide/">The Art of Consensus</a> → 
+<h1>W3C Editors' Home Page</h1></div>
+      <p class="baseline">This <strong>Guidebook</strong> is the collected wisdom of the W3C Group Chairs and other collaborators.</p>
+    </div>
+    <div class="toc">
+      <h4>Also On This Page → </h4>
+      <ul>
+        <li><a href="#intro">Introduction</a> • </li>
+        <li><a href="#start">Getting started</a> • </li>
+        <li><a href="#quality">Guidelines</a> • </li>
+        <li><a href="#grammars">Grammars</a> • </li>
+        <li><a href="#authoring">Authoring Tools</a> • </li>
+        <li>
+          <a href="#tools">Tools</a> • 
+        </li>
+        <li><a href="#javascript">JavaScript</a></li>
+      </ul>
+    </div>
+    <div class="toolbox box">
+      <h4>Nearby</h4>
+      <ul>
+        <li><a href="/pubrules">Pubrules</a></li>
+        <li><a href="../manual-of-style/">Manual of Style</a></li>
+        <li><a href="https://w3c.github.io/">W3C on GitHub</a></li>
+        <li><a href="http://lists.w3.org/Archives/Public/spec-prod/">spec-prod mailing list</a>
+        </li>
+      </ul>
+    </div>
+    <div id="Content">
+      <h2>
+        <a name="intro" id="intro">Introduction</a>
+      </h2>
+      <p>One of the main accomplishments at W3C is to write specifications and create standards out of them. While the Working Groups at large are responsible for building consensus on the technical decisions, the editors have the heavy responsibility of transforming these decisions into actual specifications.</p>
+      <p>This page tries to gather resources that can help editors do their job: documentation, tools, tutorials, etc. If you know other resources that would benefit editors by being listed here, please inform the W3C Communication Team at <a href="mailto:w3t-comm@w3.org">w3t-comm@w3.org</a>.</p>
+      <h2>
+        <a name="start" id="start">Where to start?</a>
+      </h2>
+      <p>If you are a newly appointed editor in your Working Group, here is some advice that should be useful to get you started.</p>
+      <ul>
+        <li>Get an <a href="role.html">idea of the role of an editor</a> at W3C</li>
+        <li>Check the most popular editing tools: <a href="https://tabatkins.github.io/bikeshed/">Bikeshed</a>, <a href="https://github.com/w3c/respec/wiki">respec</a></li>
+        <li>Read the <a href="/pubrules/doc/">W3C Publication Rules</a> (often referred as <q><dfn>pubrules</dfn></q>) and ask advice on the points that are unclear; if your document doesn't comply with these rules, it cannot be published as a W3C technical report.</li>
+        <li><a href="/Guide/transitions">How to Organize a Recommendation Track Transition</a> explains the process to get a document published as a technical report.</li>
+        <li>The <a href="/pubrules">Pubrules Checker</a> is a tool that can help you assess whether or not your document complies with pubrules.</li>
+        <li>Review <a href="/TR/WCAG/">WCAG</a></li>
+        <li>All W3C editors are invited to join the <a href="http://lists.w3.org/Archives/Public/spec-prod/">publicly archived mailing list &lt;spec-prod@w3.org&gt;</a> to share and discuss the techniques and tools used to produce W3C specifications.</li>
+      </ul>
+      <h2>
+        <a name="quality" id="quality">Guidelines on W3C specifications editing</a>
+      </h2>
+      <p>W3C has developed a set of resources giving advices and guidelines on editing W3C specifications in varous domains:</p>
+      <ul>
+        <li>The <a href="../manual-of-style/">W3C Manual of Style</a> is a collection of rules you're invited to follow to make your document clearer and adapted to the common style at W3C.</li>
+        <li>Begun in 1992 and only a little out of date, the <a href="../../Provider/Style/">Style Guide for online hypertext</a> by Tim Berners-Lee is a good start on writing for the Web; see also Jakob Nielsen's <a href="http://www.useit.com/alertbox/9710a.html">How Users Read on the Web</a></li>
+        <li>The <a href="../../TR/qaframe-spec/">QA Framework: Specification Guidelines</a> from the W3C Quality Assurance Activity are a work in progress that became a Candidate Recommendation in November 2003.</li>
+        <li>The Team has guidelines for a <a href="editors-draft.html">style for group-internal drafts</a> to avoid confusion with documents published on the <a href="/TR">TR page</a>. Please also review the related <a href="https://www.w3.org/Consortium/Process/#revising-wd">Working Group Heartbeat Requirement</a> of the W3C Process.</li>
+      </ul>
+      <p><a href="http://www.w3.org/People/Bos/DesignGuide/introduction">Bert Bos's essay on W3C's design principles</a> and <a href="http://www.w3.org/1999/09/specification">Tim Berners-Lee's essentials of a specification</a> may also be a useful reading.</p>
+      <p>During the internal development of a specification, make sure to distinguish official drafts from internal ones using the <a href="editors-draft.html">style for Group-internal Drafts</a>.</p>
+      <h2>
+        <a name="grammars" id="grammars">Grammars</a>
+      </h2>
+      <p>W3C editors have developed several types of HTML and XML based grammars to make it easier to develop and maintain their specifications.</p>
+      <h2>
+        <a name="authoring" id="authoring">Authoring tools</a>
+      </h2>
+      <ul>
+      <li>Check the most popular editing tools: <a href="https://tabatkins.github.io/bikeshed/">Bikeshed</a>, <a href="https://github.com/w3c/respec/wiki">respec</a></li>
+      <li><a href="http://www.bluegriffon.org/" >BlueGriffon</a> is a WYSIWYG HTML editor.</li>
+      <li>Some <a href="http://scriptlib-cg.github.com/api-design-cookbook/ ">tips and tricks for API architecture design</a></li>
+      <li>Some <a href="http://wiki.whatwg.org/wiki/Howto_spec">WhatWG conventions</a>.</li>
+      </ul>
+      <h2>
+        <a name="tools" id="tools">Tools</a>
+      </h2>
+      <p>Here are tools that can prove to be useful when developing your specification.</p>
+      <ul>
+        <li>The <a href="http://www.w3.org/pubrules">Pubrules Checker</a> provides a convenient interface to check the conformance of a document to pubrules (see <a href="http://github.com/w3c/specberus/issues">pubrules issues and tracking</a>)</li>
+        <li>The <a href="http://www.w3.org/2000/06/webdata/xslt?xslfile=http%3A%2F%2Fwww.w3.org%2F2005%2F06%2Ftr-shopping.xsl&amp;xmlfile=http%3A%2F%2Fwww.w3.org%2F2002%2F01%2Ftr-automation%2Ftr.rdf">Technical Reports shopping list</a> and the <a href="http://www.w3.org/2002/01/tr-automation/tr-biblio-ui">Bibliography Extractor</a> help building bibliographies based on other W3C Technical Reports; there is a <a href="http://lists.w3.org/Archives/Public/spec-prod/2003OctDec/0002.html">similar mechansim</a> for XMLSpec</li>
+        <li>The <a href="/2004/07/references-checker-ui">TR references checker</a> may help maintain your references list up to date. See also the <a href="/2007/05/ietf-references-checker">IETF references checker</a>.</li>
+        <li>The <a href="/2003/glossary/">W3C Glossary</a> is a repository of all the terms defined in W3C specifications (and more); a good source to find which terms have already been defined and where</li>
+        <li>The <a href="http://www.w3.org/2002/01/spellchecker">on-line Spell Checker</a> helps spot misspellings and typos; the <a href="/2002/08/diction">W3C on-line Stylistic Checker</a> helps find the most usual errors identified by the <a href="/2001/06/manual/">W3C Manual of Style</a></li>
+        <li><a href="http://esw.w3.org/topic/HtmlDiff">different tools</a> are available to produce a <code>diff</code> between 2 HTML versions of a document; W3C offers an <a href="http://www.w3.org/2007/10/htmldiff">on-line HTMLDiff service</a></li>
+        <li>The <a href="http://validator.w3.org/">MarkUp Validator</a> can help you assess whether your documents are valid HTML, MathML or SVG.</li>
+        <li>The <a href="http://jigsaw.w3.org/css-validator/">CSS Validator</a> tells you if your use of CSS is correct.</li>
+        <li>The <a href="http://validator.w3.org/checklink">Link Checker</a> catches all the broken links that may have popped up in your document.</li>
+        <li>The <a href="http://www.w3.org/2003/09/nschecker">Namespace checker</a> finds potential namespaces URIs in the documents, and makes a few checks on them</li>
+        <li><a href="http://tidy.sourceforge.net/">HTML Tidy</a>, originally by Dave Raggett and now maintained at SourceForge.net, is a lint that cleans up but does not validate HTML and XHTML. With indent off, Tidy can sometimes shave 10% or more off file size.</li>
+      </ul>
+      <p>Most of these tools can be quickly accessed using the <a href="./,tools">so called <code>,tools</code></a> interface: appending <code>,<var>keyword</var></code> to a www.w3.org URI triggers a certain tool on this URI; for instance, appending <a href=",validate"><code>,validate</code></a> to this page's URI will send it to the HTML validator.</p>
+      <h2>
+        <a name="javascript" id="javascript">Central JavaScript repository</a>
+      </h2>
+      <p>Specifications should, of course, be device-independent. But,
+      with care, you can still include certain kinds of scripts. If
+      the script you want is in W3C's <a href="../../scripts/"
+      >repository of common JavaScript libraries,</a> you're
+      recommended to link to that repository, rather than make a copy
+      of the script. (Note that, together with the common style
+      sheets, these scripts are the <em>only</em> resources that may
+      be outside the specification's own directory.)</p>
+
+      <p>There is no documentation for now (except for <a
+      href="https://www.w3.org/scripts/MathJax/" >MathJax</a>).</p>
+    </div>
+    <hr>
+    <p>Feedback is to <a href="https://github.com/orgs/w3c/teams/tilt">@w3c/tilt</a>
+       and is welcome on <a href="https://github.com/w3c/Guide/issues">GitHub</a></p>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
       <h3 id="Deliverables">Specification Development</h3>
       <ul>
         <li><a href="./editor">W3C Editors home page</a> and specifically
-          the <a href="./editors-draft">Style for Group-internal
+          the <a href="./editor/editors-draft">Style for Group-internal
             Drafts</a> </li>
         <li>Advancement on the Recommendation Track:
           <ul>

--- a/index.html
+++ b/index.html
@@ -206,8 +206,8 @@
 
       <h3 id="Deliverables">Specification Development</h3>
       <ul>
-        <li><a href="https://www.w3.org/2003/Editors/">W3C Editors home page</a> and specifically
-          the <a href="https://www.w3.org/2005/03/28-editor-style.html">Style for Group-internal
+        <li><a href="./editor">W3C Editors home page</a> and specifically
+          the <a href="./editors-draft">Style for Group-internal
             Drafts</a> </li>
         <li>Advancement on the Recommendation Track:
           <ul>


### PR DESCRIPTION
This moves:
* https://www.w3.org/2003/Editors/
* https://www.w3.org/2005/03/28-editor-style.html