### PR TITLE
Closing wg

### DIFF
--- a/process/charter.html
+++ b/process/charter.html
@@ -98,7 +98,7 @@ work. The reviews typically happen in this order:</p>
 
 <p><span class="timing">Timing:</span> Please note that these reviews take time, and people working on charters should expect the entire process to take multiple months.</p>
 
-<p><strong>Note:</strong> <a href="/2003/04/closing-group.html">Group closures</a> are addressed in other documentation.</p>
+<p><strong>Note:</strong> <a href="closing-wg.html">Group closures</a> are addressed in other documentation.</p>
 
 <h2 id="new-charters">New Charters</h2>
 

--- a/process/closing-wg.html
+++ b/process/closing-wg.html
@@ -58,7 +58,7 @@ once it has completed it's work.
 <h2 id="normal">Normal Closure</h2>
 
 <p>
-    Sometimes, after succesfull completion,
+    Sometimes, after successful completion,
     the Group is left open to perform <strong>maintenance</strong>;
     other times, it is closed and a Community Group performs this function.
 </p>

--- a/process/closing-wg.html
+++ b/process/closing-wg.html
@@ -102,7 +102,7 @@ once it has completed it's work.
     A proposal to close a Group before the end of it's chartered term
     must be explained. An Advisory Committee review takes place
     and, if that confirms that the group should be closed,
-    a W3C Decision announces closure of the group.
+    a <a href="https://www.w3.org/Consortium/Process/#def-w3c-decision">W3C Decision</a> announces closure of the group.
 </p>
 
 <p>

--- a/process/closing-wg.html
+++ b/process/closing-wg.html
@@ -52,7 +52,7 @@ type="text/css">
 the <a href="https://www.w3.org/Consortium/Process/#group-lifecyle">lifecycle
 of chartered groups</a>. 
 At a high level, W3C closes a Working Group
-once it has completed it's work.
+once it has completed its work.
 </p>
 
 <h2 id="normal">Normal Closure</h2>

--- a/process/closing-wg.html
+++ b/process/closing-wg.html
@@ -74,7 +74,7 @@ once it has completed it's work.
     </dd>
 
     <dt>PAG outcome</dt>
-    <dd>A Patent Advisory Group has determined
+    <dd>A <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Exception">Patent Advisory Group</a> has determined
         that essential claims exist which cannot be circumvented;
         so it will not be possible to create a Recommendation
         which can be freely implemented under the

--- a/process/closing-wg.html
+++ b/process/closing-wg.html
@@ -99,7 +99,7 @@ once it has completed its work.
 </dl>
 
 <p>
-    A proposal to close a Group before the end of it's chartered term
+    A proposal to close a Group before the end of its chartered term
     must be explained. An Advisory Committee review takes place
     and, if that confirms that the group should be closed,
     a <a href="https://www.w3.org/Consortium/Process/#def-w3c-decision">W3C Decision</a> announces closure of the group.

--- a/process/closing-wg.html
+++ b/process/closing-wg.html
@@ -83,7 +83,7 @@ once it has completed its work.
     </dd>
 
     <dt>Considered detrimental</dt>
-    <dd>The AB or the TAG determined that
+    <dd>The AB or the TAG has determined that
         continued operation of the groups
         would be harmful to the Web or to W3C.
     </dd>

--- a/process/closing-wg.html
+++ b/process/closing-wg.html
@@ -65,7 +65,7 @@ once it has completed it's work.
 
 <h2 id="early">Early closure</h2>
 
-<p>Exceptionally, a group may be closed before it has completed it's work:</p>
+<p>Exceptionally, a group may be closed before it has completed its work:</p>
 
 <dl>
     <dt>Insufficient resources</dt>

--- a/process/closing-wg.html
+++ b/process/closing-wg.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" >
+<title>How to Close a Working Group</title>
+<link rel="stylesheet" href="/StyleSheets/generic-base-1.css"
+type="text/css">
+<link rel="stylesheet" type="text/css" href="../assets/main.css">
+<link rel="shortcut icon" href="/Icons/WWW/Literature.gif">
+<link rel="start" href="../" >
+<style>
+  dt {font-weight: bold; }
+  .timing { font-style: italic }
+   body {counter-reset:section;}
+    h2 {counter-reset:subsection;}
+    h2:before
+    {
+    counter-increment:section;
+    content: counter(section) ". "}
+    h3:before
+    {
+    counter-increment:subsection;
+    content:counter(section) "." counter(subsection) " ";
+    }
+    h4:before
+    {
+    counter-increment:subsubsection;
+  content:counter(section) "." counter(subsection) "." counter(subsubsection) " ";
+    }
+    h4.notoc:before {
+    content: "";
+    }
+</style>
+</head>
+<body>
+
+<div id="header"> <span class="logo"><a href="https://www.w3.org/"><img src="https://www.w3.org/Icons/WWW/w3c_home_nb"
+        alt="W3C"
+        height="48"
+        width="72"></a>
+</span>
+  <div class="breadcrumb"> <a href="https://www.w3.org/participate/">Participate</a> →
+    <h1>How to Close a Working Group</h1>
+  </div>
+  <p class="baseline">This <strong>Guidebook</strong> is the collected
+    wisdom of the W3C Group Chairs, team contacts and other contributors.</p>
+</div>
+
+<h2 id="intro">Introduction</h2>
+
+<p>The W3C Process describes
+the <a href="https://www.w3.org/Consortium/Process/#group-lifecyle">lifecycle
+of chartered groups</a>. 
+At a high level, W3C closes a Working Group
+once it has completed it's work.
+</p>
+
+<h2 id="normal">Normal Closure</h2>
+
+<p>
+    Sometimes, after succesfull completion,
+    the Group is left open to perform <strong>maintenance</strong>;
+    other times, it is closed and a Community Group performs this function.
+</p>
+
+<h2 id="early">Early closure</h2>
+
+<p>Exceptionally, a group may be closed before it has completed it's work:</p>
+
+<dl>
+    <dt>Insufficient resources</dt>
+    <dd>There is insufficient developer or implementer interest
+        to sustain the group, and the Team proposes to close it.
+    </dd>
+
+    <dt>PAG outcome</dt>
+    <dd>A Patent Advisory Group has determined
+        that essential claims exist which cannot be circumvented;
+        so it will not be possible to create a Recommendation
+        which can be freely implemented under the
+        W3C Royalty-Free Patent Policy;
+        thus, it is proposed that the group should be closed.
+    </dd>
+
+    <dt>Considered detrimental</dt>
+    <dd>The AB or the TAG determined that
+        continued operation of the groups
+        would be harmful to the Web or to W3C.
+    </dd>
+
+    <dt>Finished early</dt>
+    <dd>All the Recommendation-track deliverables
+        have been completed early,
+        and no other work in scope of the current charter
+        remains to be done.
+        The options are to just let the charter run until it expires,
+        or to formally close the group early.
+    </dd>
+</dl>
+
+<p>
+    A proposal to close a Group before the end of it's chartered term
+    must be explained. An Advisory Committee review takes place
+    and, if that confirms that the group should be closed,
+    a W3C Decision announces closure of the group.
+</p>
+
+<p>
+    Note that, if the Group has Recommendation-track specifications in development,
+    and they have not yet reached W3C Recommendation status,
+    closing the group 
+    <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-disclosure-termination">
+    terminates Disclosure Obligations</a> for those specifications.
+</p>
+
+<p>
+    There is <em>Team-only</em> documentation of the 
+    <a href="https://www.w3.org/2003/04/closing-group.html">detailed steps for closing a group.</a>
+</p>
+
+<hr>
+
+  <p>Feedback is to <a href="https://github.com/orgs/w3c/teams/guidebook">@w3c/guidebook</a> and
+      is welcome on <a href="https://github.com/w3c/Guide/issues">GitHub</a></p>
+</body>
+</html>


### PR DESCRIPTION
The documentation on closing a WG was Team-only, there was nothing Public.

Process 2023 [adds requirements (AC review, W3C Decision) for early closure](https://www.w3.org/2023/Process-20230612/#GeneralTermination).

The Team-only page remains, it has a different audience and is more about implementing group closure than deciding to close.