### PR TITLE
Charter extensions

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -62,6 +62,7 @@ div#header .baseline {
 .toolbox {
 	background: #e2edfe; 
 	border: thin black solid;
+	margin: 1em;
 }
 
 .toolbox h4 {color: white;
@@ -179,4 +180,12 @@ var, code {
 .rfc2119 {
   text-transform: lowercase;
   font-weight: bold
+}
+.warning {
+  background: hsla(40,100%,50%,0.95);
+  color: black;
+  padding: .75em 1em;
+  border: red solid 1px;
+  box-shadow: 0 2px 8px black;
+  text-align: center;
 }

--- a/process/charter-extensions.html
+++ b/process/charter-extensions.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html  lang="en">
+<head>
+<meta charset="utf-8">
+<title>Policy on Extending W3C Group Charters</title>
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/generic-base-1.css" type="text/css">
+<link rel="stylesheet" type="text/css" href="../assets/main.css">
+<link rel="shortcut icon" href="https://www.w3.org/Icons/WWW/Literature.gif">
+</head>
+<body>
+  <div id="header">
+  <span class="logo">
+    <a href="/">
+      <img src="https://www.w3.org/Icons/WWW/w3c_home_nb" alt="W3C" height="48" width="72">
+    </a>
+  </span>
+  <div class="breadcrumb"><a href="https://www.w3.org/participate/">Participate</a> → <a href="https://www.w3.org/Guide/">The Art of Consensus</a> → 
+<h1>Policy on W3C Group Charter End Dates</h1></div>
+  <p class="baseline">This <strong>Guidebook</strong> is the collected wisdom of the W3C Group Chairs and other collaborators.</p>
+</div>
+
+<div class="toolbox box">
+  <h4>Related Resources</h4>
+  <ul>
+      <li><a
+          href="charter.html">How to Create a Working Group or Interest Group</a></li>
+      <li><a
+          href="tilt/">Technical issues Lead Team</a></li>
+  </ul>
+</div>
+
+    <h2>Charter Review</h2>
+    <p>From time to time a Working Group or Interest Group will not have
+      completed its work prior to the end date of its group charter.&nbsp; The
+      Director may entertain requests to extend the charter.&nbsp; The Advisory
+      Board has asked the CEO to monitor charter end dates and group progress more
+      closely and in particular to clarify the status of a group that wishes to
+      continue to work past the end of its charter.</p>
+    <ol>
+      <li>On a quaterly basis, <a href="https://www.w3.org/staff/strat/">Strategy</a>
+        will review the
+        progress of all chartered groups and the Team Contacts will present a plan
+        for each Group whose charter will have expired prior to the following
+        quarterly review meeting. Team Contacts are encouraged to look ahead
+        further than the next review meeting and report expectations for groups
+        whose charter expires within six months of each review meeting.</li>
+      <li>Strategy will review each such plan during the quarterly meetings and reach
+        an approved consensus plan.&nbsp; The Advisory Board encourages the Team to
+        grant charter extensions sparingly.</li>
+      <li>Any approved plan that re-charters a group, extends a charter,
+	or closes a Group must be
+        announced to the Membership, with rationale, prior to the current
+        charter expiration.</li>
+      <li>Any approved plan to defer a decision; e.g. to see if the group
+        reaches a specific milestone, must specify the date of a regular weekly
+        Strategy meeting where a decision will be taken.&nbsp; The date for this Strategy
+        discussion must be no later than
+        <ol style="list-style-type: lower-alpha; margin-top: 1em;">
+          <li>one month prior to the charter expiration if an AC review of the
+            change to the charter is not expected or</li>
+          <li style="margin-top:0">three months prior to the charter expiration
+            if an AC review of the proposed change to the charter might be
+            conducted. </li>
+        </ol>
+        <p>Whether or not an AC review is conducted, a decision on the current
+          charter of the Group must be announced to the Membership, with
+          rationale, prior to the charter expiration.&nbsp; TiLT may grant short
+          charter extensions if AC review has not completed prior to the current
+          charter end date.</p>
+      </li>
+      <li>Publication Requests on behalf of a Group whose charter has expired
+        more than five business days prior to the date of publication will be
+        denied.&nbsp; This five business day allowance is meant only to
+        accommodate unforeseen circumstances out of the Group's control.</li>
+      <li>Any Group whose charter has expired should not request nor should it
+        expect W3C Staff support.  Strategy may choose to continue some level of
+        Staff support.  Changes in Staff support decided by Function Leads will be
+        communicated to the chair(s) of the Group.</li>
+    </ol>
+
+    <hr>
+    <p>Feedback is to <a href="https://github.com/orgs/w3c/teams/tilt">@w3c/tilt</a>
+       and is welcome on <a href="https://github.com/w3c/Guide/issues">GitHub</a></p>
+  </body>
+</html>

--- a/process/charter.html
+++ b/process/charter.html
@@ -144,11 +144,11 @@ work. The reviews typically happen in this order:</p>
   <br/><span class="timing">Timing:</span> Horizontal reviewers will usually respond within two weeks, though it is wise to allow for additional time. The <a href="#charter-shepherd">charter shepherd</a> may use the team-horizontal list to reach all the horizontal reviewers.
 </dd>
   <dt>Prepare for TiLT Review</dt>
-  <dd>Horizontal and other reviews may result in changes to the charter or objections. The charter shepherd should note in the <a href="./tilt/index.html#request">request to TiLT</a> the horizontal review status (including completed reviews and any timeouts).
+  <dd>Horizontal and other reviews may result in changes to the charter or objections. The charter shepherd should note in the <a href="./tilt/#request">request to TiLT</a> the horizontal review status (including completed reviews and any timeouts).
   </dd>
     <dt>Request approval from TiLT</dt>
-  <dd>When the charter shepherd is satisfied that as much progress as possible has been made, they <a href="./tilt/index.html#request">request approval from TiLT</a>. Record in the <a href="#pipeline">pipeline</a> issue that a TiLT decision has been requested. TiLT informs the charter shepherd of their decision in the <a href="#pipeline">pipeline</a> issue.
-  <br/><span class="timing">Timing:</span> Allow approximately 2 weeks, but see <a href="./tilt/index.html#timing">Timing of responses from TiLT</a> for details.
+  <dd>When the charter shepherd is satisfied that as much progress as possible has been made, they <a href="./tilt/#request">request approval from TiLT</a>. Record in the <a href="#pipeline">pipeline</a> issue that a TiLT decision has been requested. TiLT informs the charter shepherd of their decision in the <a href="#pipeline">pipeline</a> issue.
+  <br/><span class="timing">Timing:</span> Allow approximately 2 weeks, but see <a href="./tilt/#timing">Timing of responses from TiLT</a> for details.
   </dd>
 </dl>
 
@@ -162,7 +162,7 @@ work. The reviews typically happen in this order:</p>
   <dt>Prepare for AC Review</dt>
   <dd>Work with the Communications Team to organize Advisory Committee review of a charter (see <a href="#organize-cfr">implementation details for the review</a>).</dd>
   <dt>Monitor AC Review</dt>
-  <dd>Once the AC is underway, monitor responses and <a href="https://www.w3.org/2017/12/formal-objections.html">manage any formal objections</a>. Ensure that the charter receives <a href="#baseline-support">sufficient support from the Membership</a>.
+  <dd>Once the AC is underway, monitor responses and <a href="formal-objections">manage any formal objections</a>. Ensure that the charter receives <a href="#baseline-support">sufficient support from the Membership</a>.
 <br/><span class="timing">Timing:</span>
 <ul>
   <li><a href="https://www.w3.org/Consortium/Process/#CharterReview">Per the W3C Process</a>, the review period must be at least 28 days.</li>
@@ -173,8 +173,8 @@ work. The reviews typically happen in this order:</p>
   <dt>Manage changes resulting from review</dt>
   <dd>As a result of review, make any requested very minor changes (in place) to the charter. If substantive changes are proposed, the initiate review of those proposed changes. In either case, the Team follows a process for <a href="#manage-changes">managing changes to charters after review</a>.</dd>
   <dt>Request approval from TiLT</dt>
-  <dd>Once the review has ended and <a href="https://www.w3.org/2017/12/formal-objections.html">formal objections addressed</a>, the charter shepherd <a href="./tilt/index.html#request">requests approval from TiLT</a>. Record in the <a href="#pipeline">pipeline</a> issue that a TiLT decision has been requested. TiLT informs the charter shepherd of their decision.
-  <br/><span class="timing">Timing:</span> Allow approximately 2 weeks, but see <a href="./tilt/index.html#timing">Timing of responses from TiLT</a> for details.
+  <dd>Once the review has ended and <a href="formal-objections">formal objections addressed</a>, the charter shepherd <a href="./tilt/#request">requests approval from TiLT</a>. Record in the <a href="#pipeline">pipeline</a> issue that a TiLT decision has been requested. TiLT informs the charter shepherd of their decision.
+  <br/><span class="timing">Timing:</span> Allow approximately 2 weeks, but see <a href="./tilt/#timing">Timing of responses from TiLT</a> for details.
   </dd>
 </dl>
 
@@ -195,8 +195,8 @@ work. The reviews typically happen in this order:</p>
 
 <dl>
   <dt>Request approval from TiLT</dt>
-  <dd>The charter shepherd <a href="./tilt/index.html#request">requests approval of the short extension by TiLT</a>.
-  <br/><span class="timing">Timing:</span> Allow approximately 2 weeks, but see <a href="./tilt/index.html#timing">Timing of responses from TiLT</a> for details.
+  <dd>The charter shepherd <a href="./tilt/#request">requests approval of the short extension by TiLT</a>.
+  <br/><span class="timing">Timing:</span> Allow approximately 2 weeks, but see <a href="./tilt/#timing">Timing of responses from TiLT</a> for details.
   </dd>
   <dt>Request extension notice</dt>
   <dd>If the decision is positive, request that the Communications Team <a href="#announce-extension">announce an extension</a>.</dd>

--- a/process/charter.html
+++ b/process/charter.html
@@ -189,7 +189,7 @@ work. The reviews typically happen in this order:</p>
 
 <h3 id="extension-request">Request for short-term extension</h3>
 
-<p>The W3C Process describes the <a href="https://www.w3.org/Consortium/Process/#charter-extension">charter extensions</a> and when they may occur.  No Advisory Comittee review is required for short-term extensions. Since 2015, the Team has adopted a <a href="https://www.w3.org/2015/04/charter-extensions.html">policy on group charter end dates</a>: a charter may only be extended without AC review for six months or less, otherwise it must recharter.</p>
+<p>The W3C Process describes the <a href="https://www.w3.org/Consortium/Process/#charter-extension">charter extensions</a> and when they may occur.  No Advisory Comittee review is required for short-term extensions. Since 2015, the Team has adopted a <a href="charter-extensions">policy on group charter end dates</a>: a charter may only be extended without AC review for six months or less, otherwise it must recharter.</p>
 
 <p>For a short-term extension, the charter shepherd roles include:</p>
 


### PR DESCRIPTION
Moves  https://www.w3.org/2015/04/charter-extensions.html

and assign the role of monitoring charter end dates to Strategy.

fyi @w3c/tilt 