### PR TITLE
Editorial and QA on adv-notice.html

### DIFF
--- a/process/adv-notice.html
+++ b/process/adv-notice.html
@@ -36,22 +36,22 @@ this document.</p>
 <dt>Who/Where</dt>
 <dd>
 <p>The <a href="https://www.w3.org/staff/strat/">Strategy team</a> determines when
-to inform the AC of work-in-progress. These announcements are sent by <a href="https://www.w3.org/staff/comm/">MarComm</a>
-to w3c-ac-members@w3.org and cc:
+to inform the AC of work-in-progress. These announcements are sent by the <a href="https://www.w3.org/staff/comm/">W3C Communications Team</a>
+to w3c-ac-members@w3.org and then forwarded to:
   chairs@w3.org.</p>
 <p>As of May 2014, unless an advance notice strongly requires
 Member-only confidentiality (which should be rare), we also inform the
 public
 via <a href="https://lists.w3.org/Archives/Public/public-new-work/">public-new-work@w3.org</a>;
 see <a href="https://lists.w3.org/Archives/Public/public-new-work/2022Mar/0012.html">example</a>. This
-is done by MarComm.</p>
+is done by the W3C Communications Team.</p>
 </dd>
 
 <dt>When</dt>
 <dd>
 <p>Specialists, in conjunction with the Strategy Lead, make this
-decision based on early assessment of the factors in
-"<a href='https://github.com/w3c/strategy/blob/master/3.Evaluation.md'>Evaluation</a>"[3]
+decision based on early assessment of the factors available in the
+"<a href='https://github.com/w3c/strategy/blob/master/3.Evaluation.md'>Evaluation</a>" section of the Funnel,
 as well as considering when it is useful to encourage broader input to
 discussion. In the Process-required notice to the AC, the Strategy
 team will give an early status report on the work and likely timeline
@@ -62,7 +62,7 @@ evaluating possible work, and seeks wider feedback.
 </p>
 </dd>
 
-<dt>What</dt>
+<dt>How/What</dt>
 <dd>
 <p>There is
 a <a href="https://www.w3.org/new-doc-from-template?location=%2FTeam%2F&amp;template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fadv-charter.html&amp;submit=Continue...">template
@@ -77,7 +77,7 @@ information:</p>
 <li>A summary of the intended work</li>
 <li>A statement welcoming the Members to
 use w3c-ac-forum for general expressions
-of interest and support. </li>
+of interest and support.</li>
 <li>A request that Members send substantive comments and engage
 on substantive discussion on a different mailing list or github repository
 (i.e., <strong>other than w3c-ac-forum</strong>).</li>
@@ -91,7 +91,7 @@ be the names of one or more people on the Team.</li>
 information:</p>
 
 <ul>
-<li>Expectations about when a formal Advisory Commitee Review will begin.</li>
+<li>Expectations about when a formal Advisory Commitee Review might begin.</li>
 </ul>
 
 <p>The advance notice announcement to the Membership MAY include this
@@ -100,7 +100,7 @@ information:</p>
 <ul>
 <li>Pointers to draft materials. In other words, the announcement is
 not required to include a draft charter, but if one is available,
-please do send it to the AC.</li>
+please include it.</li>
 <li>Information about other mailing lists for comments, as the
 situation requires.</li>
 </ul>
@@ -119,36 +119,16 @@ in development early (on w3c-ac-forum), and to enable those interested in
 shaping a charter to participate on a separate list (so as not to
 flood w3c-ac-forum).</p>
 
-<p>Hence the sentence in the Process Document: "Advisory Committee
-representatives MAY express their general support on the Advisory
-Committee discussion list."</p>
+<p>Hence the sentence in the Process Document: "<i></i>Advisory Committee
+representatives MAY provide feedback on the Advisory
+Committee discussion list or via other designated channels.</i>"</p>
 
 <p>These ideas are further discussed in <cite><a
 href="http://www.w3.org/2002/05/rec-tips">Tips for Getting to
 Recommendation Faster</a></cite>, in particular:</p>
 
 <blockquote>
-
-<p>Start as early as Group charter development time, by garnering support from
-fellow W3C Members on w3c-ac-forum. When there is substantial support
-for new work among the Members, the Team may create a special mailing
-list for discussion among Members and Team about Group charter development.</p>
-</blockquote>
-
-<p>The Process Document requirements, excerpted here, are:</p>
-
-<blockquote>
-<p>The Team MUST notify the Advisory Committee when a charter for a
-new Working Group or Interest Group is in development. This is
-intended to raise awareness, even if no formal proposal is yet
-available. Advisory Committee representatives MAY provide feedback on
-the Advisory Committee discussion list or via other designated
-channels.</p>
-<p>W3C MAY begin work on a Working Group or Interest Group charter at
-any time.</p>
-<p style="text-align:
-right">-- <cite><a href="https://www.w3.org/Consortium/Process/#WGCharterDevelopment">Process
-Document, section 4.1 "Initiating Charter Development"</a></cite></p>
+<p>When a Charter is proposed to the Advisory Committee, garner support from fellow W3C Members on w3c-ac-forum. When there is substantial support for new work among the Members, the Team may create a special mailing list for discussion among Members and Team about Group charter development. Start discussions with proposals, calendars, statements of expected resource commitments, and other such signals.</p>
 </blockquote>
 
 <hr title="address separator" />


### PR DESCRIPTION
QA and updates (including to ensure matching "excerpted" texts from the process and from the Tips document).
Also, I removed the excerpt from the Process at the bottom section on "background", so that the document is shorter and we have one fewer place to update if the Process text changes. The requirement in question is linked from the top of the doc.