### PR TITLE
Remove link to outdated 'Scribe 101' page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,10 +143,8 @@
         <li id="meetingbots">Running a Meeting (especially a teleconference) on <a href="https://www.w3.org/Project/IRC/">IRC</a>
           (<a href="https://irc.w3.org/">Web client</a>):
           <ul>
-            <li><a href="https://www.w3.org/2008/04/scribe.html">Scribe 101</a>: Taking meeting
-              minutes using W3C IRC tools</li>
             <li><a href="https://w3c.github.io/scribe2/scribedoc.html">Quick
-                start guide</a> more details on setting up tools for managing an agenda,
+                start guide</a> on setting up tools for managing an agenda,
               generating minutes, and updating issues lists</li>
             <li><a href="https://www.w3.org/Guide/meetings/zoom">Scheduling teleconferences</a></li>
 	    <li><a href="https://www.w3.org/Guide/meetings/organize.html#calendars">Group calendars</a></li>


### PR DESCRIPTION
the "Scribe 101" page is outdated, and has been marked as such. The folloling link "Quick Start Guide" serves a similar purpose, but is more up-to-date.