### PR TITLE
inform new-work@ietf

### DIFF
--- a/process/adv-notice.html
+++ b/process/adv-notice.html
@@ -39,11 +39,11 @@ this document.</p>
 to inform the AC of work-in-progress. These announcements are sent by the <a href="https://www.w3.org/staff/comm/">W3C Communications Team</a>
 to w3c-ac-members@w3.org and then forwarded to:
   chairs@w3.org.</p>
-<p>As of May 2014, unless an advance notice strongly requires
+<p>Unless an advance notice strongly requires
 Member-only confidentiality (which should be rare), we also inform the
 public
-via <a href="https://lists.w3.org/Archives/Public/public-new-work/">public-new-work@w3.org</a>;
-see <a href="https://lists.w3.org/Archives/Public/public-new-work/2022Mar/0012.html">example</a>. This
+via <a href="https://lists.w3.org/Archives/Public/public-new-work/">public-new-work@w3.org</a> (
+see <a href="https://lists.w3.org/Archives/Public/public-new-work/2022Mar/0012.html">example</a>) and <a href="https://www.ietf.org/mailman/listinfo/new-work">new-work@ietf.org</a>. This
 is done by the W3C Communications Team.</p>
 </dd>
 


### PR DESCRIPTION
added to instructions to inform also new-work@ietf.org as this list is to exchange (early) information about work going on in each  SDOs (Standards Development Organizations).