### PR TITLE
Add URL recommendation for the charter

### DIFF
--- a/process/charter.html
+++ b/process/charter.html
@@ -395,7 +395,7 @@ following status sentence at the top:
 </li>
 <li>All relevant mailing lists exist. If not, the Team Contact may <a href="/Systems/Mail/Request/">create the mailing list(s)</a>.</li>
 <li>The main mailing list is associated with the group via the <a href="/2011/04/dbwg/group-services">Group Service Management</a> interface.</li>
- <li>Make sure the charter is public (since 2007, charters are public during AC review) and any final edits (e.g., addition of link to page for joining the group) have been made.</li>
+ <li>Make sure the charter is public (since 2007, charters are public during AC review) and any final edits (e.g., addition of link to page for joining the group) have been made. If the group already exists, the new charter and the old charter should be in two different URLs.</li>
 	<li>Customize the <a href="https://github.com/w3c/onboarding">"onboarding" message</a> that will be sent to participants as they join the group.</li>
 	</ol>
 

--- a/process/charter.html
+++ b/process/charter.html
@@ -395,7 +395,7 @@ following status sentence at the top:
 </li>
 <li>All relevant mailing lists exist. If not, the Team Contact may <a href="/Systems/Mail/Request/">create the mailing list(s)</a>.</li>
 <li>The main mailing list is associated with the group via the <a href="/2011/04/dbwg/group-services">Group Service Management</a> interface.</li>
- <li>Make sure the charter is public (since 2007, charters are public during AC review) and any final edits (e.g., addition of link to page for joining the group) have been made. If the group already exists, the new charter and the old charter should be in two different URLs.</li>
+ <li>Make sure the charter is public (since 2007, charters are public during AC review) and any final edits (e.g., addition of link to page for joining the group) have been made. If the group already exists, the new charter and the old charter should have two different URLs.</li>
 	<li>Customize the <a href="https://github.com/w3c/onboarding">"onboarding" message</a> that will be sent to participants as they join the group.</li>
 	</ol>
 


### PR DESCRIPTION
To make the announcement of the new charter smoother, mention that the new charter and the old charter should be in two different URLs.

See also: https://lists.w3.org/Archives/Team/sysreq/2024Oct/0130.html (team-only)