### PR TITLE
No horizontal review for PSIG

### DIFF
--- a/process/charter.html
+++ b/process/charter.html
@@ -143,6 +143,7 @@ href="/policies/process/#WGCharterDevelopment">advance notice to the W3C Advisor
   <dd>Soon after, or in parallel, initiate <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a>. This is done by
     adding the "<a href="https://github.com/w3c/strategy/labels/Horizontal%20review%20requested">Horizontal review requested</a>" label to the issue in the <a href="#pipeline">pipeline</a>.
   <br/><span class="timing">Timing:</span> Horizontal reviewers will usually respond within two weeks, though it is wise to allow for additional time. The charter shepherd may use the team-horizontal list to reach all the horizontal reviewers.
+  <br>Groups that do not hold technical discussions, such as the Patents and Standards Interest Group, are not required to do an horizontal review.
 </dd>
   <dt>Prepare for TiLT Review</dt>
   <dd>

--- a/process/charter.html
+++ b/process/charter.html
@@ -143,7 +143,7 @@ href="/policies/process/#WGCharterDevelopment">advance notice to the W3C Advisor
   <dd>Soon after, or in parallel, initiate <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a>. This is done by
     adding the "<a href="https://github.com/w3c/strategy/labels/Horizontal%20review%20requested">Horizontal review requested</a>" label to the issue in the <a href="#pipeline">pipeline</a>.
   <br/><span class="timing">Timing:</span> Horizontal reviewers will usually respond within two weeks, though it is wise to allow for additional time. The charter shepherd may use the team-horizontal list to reach all the horizontal reviewers.
-  <br>Groups that do not hold technical discussions, such as the Patents and Standards Interest Group, are not required to do an horizontal review.
+  <br>Horizontal reviews are not required for Groups that do not hold technical discussions, such as the Patents and Standards Interest Group.
 </dd>
   <dt>Prepare for TiLT Review</dt>
   <dd>


### PR DESCRIPTION
Since PSIG does not have technical documents nor discussions, it doesn't make sense to do horizontal reviews for it.