### PR TITLE
Remove custom style that was adding margin/padding between sections

### DIFF
--- a/transitions/index.html
+++ b/transitions/index.html
@@ -2172,11 +2172,7 @@ Note: Info about features at risk is required in status section per pubrules
 		})();
 	</script>
 
-<style>
-		div.l-box + h2 {
-                        padding-top: 1.25em;
-                }
-
+	<style>
 		/******************************************************************************/
 		/*                             Colored Boxes                                  */
 		/******************************************************************************/

--- a/transitions/nextstep.html
+++ b/transitions/nextstep.html
@@ -48,12 +48,6 @@ toc: false
 	<li><a href="https://www.w3.org/policies/process/#Reports">Recommendation Track Process</a></li>
 </ul>
 
-<style>
-	div.field {
-		margin-bottom: 2em;
-	}
-</style>
-
 <script type="module">
 import { fetchW3C } from 'https://w3c.github.io/gargantua/fetch-utils.js';
 

--- a/transitions/wide-review-request.html
+++ b/transitions/wide-review-request.html
@@ -74,9 +74,6 @@ Subject: <span id='spec_shortname'></span> <span id='spec_date'></span>
 </ul>
 
 <style>
-#resources {
-  margin-top: 1.5em;
-}
 #step_list {
   list-style: none;
 }


### PR DESCRIPTION
This is not needed anymore as the content is now part of `component--text`
cf https://github.com/w3c/w3c-jekyll-theme/pull/4