### PR TITLE
Move several documents under the guide repository

### DIFF
--- a/_data/submenu-publication-policies.yml
+++ b/_data/submenu-publication-policies.yml
@@ -9,13 +9,16 @@ pages:
   url: https://www.w3.org/pubrules/doc
 
 - title: Version Management in W3C Technical Reports
-  url: https://www.w3.org/2005/05/tr-versions
+  url: /guide/editor/versioning
+  html: /editor/versioning.html
 
 - title: URIs for W3C Namespaces
-  url: https://www.w3.org/2005/07/13-nsuri
+  url: /guide/editor/namespaces
+  html: /editor/namespaces.html
 
-- title: How to Register a Media Type for a W3C Specification
-  url: https://www.w3.org/2020/01/registering-mediatypes
+- title: Register a Media Type for a W3C Specification
+  url: /guide/editor/mediatypes
+  html: /editor/mediatypes.html
 
 - title: XPointer Scheme Name Registry Policy
   url: https://www.w3.org/2005/04/xpointer-policy

--- a/editor/mediatypes.md
+++ b/editor/mediatypes.md
@@ -7,19 +7,19 @@ All formats defined by W3C specifications are of general interest to the Interne
 
 ## Status of This Document
 
-This document explains the procedures available to register an Internet Media Type for a format defined by a W3C specification in the [IANA registry](https://www.iana.org/assignments/media-types/media-types.xhtml). It is being maintained by [Philippe Le Hégaret](mailto:plh@w3.org) who, together with Wendy Seltzer, is serving as IETF/W3C liaison.
+This document explains the procedures available to register an Internet Media Type for a format defined by a W3C specification in the [IANA registry](https://www.iana.org/assignments/media-types/media-types.xhtml). It is being maintained by [Philippe Le Hégaret](mailto:plh@w3.org) who, together with Simone Onofri, is serving as IETF/W3C liaison.
 
 A new process, [BCP 13](https://www.rfc-editor.org/info/bcp13), for registering Mime media types is defined in [Media Type Specifications and Registration Procedures](https://datatracker.ietf.org/doc/html/rfc6838) together with [Multipurpose Internet Mail Extensions (MIME) Part Four: Registration Procedures](https://datatracker.ietf.org/doc/html/rfc4289), which covers IANA registration procedures for MIME external body access types and content-transfer-encodings. While the first document hasn’t been formally approved, it is our understanding that this is the process followed by the IETF and the IESG.
 
 The TAG refers to this document in its April 2004 Finding [Internet Media Type registration, consistency of use](https://www.w3.org/2001/tag/2004/0430-mime):
 
-> W3C Working Groups engaged in defining a format follow How to Register a Media Type with IANAto register an Internet Media Type (defined in [\[RFC2046\]](https://datatracker.ietf.org/doc/html/rfc2046)) for the format.
+> W3C Working Groups engaged in defining a format follow How to Register a Media Type with IANA to register an Internet Media Type (defined in [\[RFC2046\]](https://datatracker.ietf.org/doc/html/rfc2046)) for the format.
 
 ## Registration process
 
 This procedure is based on [Media Type Specifications and Registration Procedures](https://datatracker.ietf.org/doc/html/rfc6838).
 
-*Note:* Once a media type has been published by the IANA, the owner may request a change to its definition. The same procedure that would be appropriate for the original registration request is used to process a change request. See also [Section 5.5, Change Procedures](https://datatracker.ietf.org/doc/html/rfc6838/#section-5.5).
+*Note:* Once a media type has been published by the IANA, the owner may request a change to its definition. The same procedure that would be appropriate for the original registration request is used to process a change request. See also [Section 5.5, Change Procedures](https://datatracker.ietf.org/doc/html/rfc6838/#section-5.5) in RFC 6838.
 
 1. Draft a proposal for the Media Type registration as a normative part of your specification, following the instructions in [Media Type Specifications and Registration Procedures](https://datatracker.ietf.org/doc/html/rfc6838), section 4, and the template in section 10. Make sure that this part of the specification is readable on its own, without the context of the specification. For Additional Media Type Structured Syntax Suffixes, such as `+xml` or `+json`, see [RFC 6839](https://datatracker.ietf.org/doc/html/rfc6839) and [RFC 7303](https://datatracker.ietf.org/doc/html/rfc7303) requirements and section [4.5.7 Media types for XML](https://www.w3.org/TR/webarch/#xml-media-types) of the [World Wide Web Architecture](https://www.w3.org/TR/webarch/) as well. In the introduction to the relevant section, say that this registration is for community review and will be submitted to the IESG for review, approval, and registration with IANA.
 1. One to two months prior to Candidate Recommendation: Send an email to the mailing list [media-types@iana.org](mailto:media-types@iana.org) asking for comments on the Media Type section of your specification:
@@ -32,7 +32,7 @@ This procedure is based on [Media Type Specifications and Registration Procedure
 3. In preparation for Candidate Recommendation:
    
    - Change the introduction to the registration information to say that it is being submitted to the IESG for review, approval, and registration with IANA.
-   - Fill the [IANA form](https://www.iana.org/form/media-types), listed in [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml). The IANA Services Specialist will check with [Wendy Seltzer](mailto:wseltzer@w3.org) and [Philippe Le Hégaret](mailto:plh@w3.org) to validate the request on behalf ot W3C.
+   - Fill the [IANA form](https://www.iana.org/form/media-types), listed in [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml). The IANA Services Specialist will check with [Philippe Le Hégaret](mailto:plh@w3.org) and [Simone Onofri](mailto:simone@w3.org) to validate the request on behalf ot W3C.
 4. In preparation for Proposed Recommendation and Recommendation:
    
    1. Check on progress of registration, first directly at [IANA](https://www.iana.org/assignments/media-types/), and if your type is not yet registered there, contact [iana-mime-comment](mailto:iana-mime-comment@iana.org).

--- a/editor/mediatypes.md
+++ b/editor/mediatypes.md
@@ -1,5 +1,5 @@
 ---
-title: Register an Internet Media Type for a W3C Spec
+title: Register an Internet Media Type for a W3C Specification
 submenu: [publication-policies]
 toc: true
 ---

--- a/editor/mediatypes.md
+++ b/editor/mediatypes.md
@@ -1,5 +1,6 @@
 ---
 title: Register an Internet Media Type for a W3C Spec
+submenu: [publication-policies]
 toc: true
 ---
 

--- a/editor/mediatypes.md
+++ b/editor/mediatypes.md
@@ -1,0 +1,52 @@
+---
+title: Register an Internet Media Type for a W3C Spec
+toc: true
+---
+
+All formats defined by W3C specifications are of general interest to the Internet Community and are therefore registered in the standards tree (formerly IETF tree), which requires approval by the IESG.
+
+## Status of This Document
+
+This document explains the procedures available to register an Internet Media Type for a format defined by a W3C specification in the [IANA registry](https://www.iana.org/assignments/media-types/media-types.xhtml). It is being maintained by [Philippe Le Hégaret](mailto:plh@w3.org) who, together with Wendy Seltzer, is serving as IETF/W3C liaison.
+
+A new process, [BCP 13](https://www.rfc-editor.org/info/bcp13), for registering Mime media types is defined in [Media Type Specifications and Registration Procedures](https://datatracker.ietf.org/doc/html/rfc6838) together with [Multipurpose Internet Mail Extensions (MIME) Part Four: Registration Procedures](https://datatracker.ietf.org/doc/html/rfc4289), which covers IANA registration procedures for MIME external body access types and content-transfer-encodings. While the first document hasn’t been formally approved, it is our understanding that this is the process followed by the IETF and the IESG.
+
+The TAG refers to this document in its April 2004 Finding [Internet Media Type registration, consistency of use](https://www.w3.org/2001/tag/2004/0430-mime):
+
+> W3C Working Groups engaged in defining a format follow How to Register a Media Type with IANAto register an Internet Media Type (defined in [\[RFC2046\]](https://datatracker.ietf.org/doc/html/rfc2046)) for the format.
+
+## Registration process
+
+This procedure is based on [Media Type Specifications and Registration Procedures](https://datatracker.ietf.org/doc/html/rfc6838).
+
+*Note:* Once a media type has been published by the IANA, the owner may request a change to its definition. The same procedure that would be appropriate for the original registration request is used to process a change request. See also [Section 5.5, Change Procedures](https://datatracker.ietf.org/doc/html/rfc6838/#section-5.5).
+
+1. Draft a proposal for the Media Type registration as a normative part of your specification, following the instructions in [Media Type Specifications and Registration Procedures](https://datatracker.ietf.org/doc/html/rfc6838), section 4, and the template in section 10. Make sure that this part of the specification is readable on its own, without the context of the specification. For Additional Media Type Structured Syntax Suffixes, such as `+xml` or `+json`, see [RFC 6839](https://datatracker.ietf.org/doc/html/rfc6839) and [RFC 7303](https://datatracker.ietf.org/doc/html/rfc7303) requirements and section [4.5.7 Media types for XML](https://www.w3.org/TR/webarch/#xml-media-types) of the [World Wide Web Architecture](https://www.w3.org/TR/webarch/) as well. In the introduction to the relevant section, say that this registration is for community review and will be submitted to the IESG for review, approval, and registration with IANA.
+1. One to two months prior to Candidate Recommendation: Send an email to the mailing list [media-types@iana.org](mailto:media-types@iana.org) asking for comments on the Media Type section of your specification:
+   
+   - Include a pointer to and a plaintext copy (not just an attachment) of the Media Type registration section in your email to [media-types@iana.org](mailto:media-types@iana.org).
+   - Make sure you address and reply to comments and questions on [media-types@iana.org](mailto:media-types@iana.org). If you change the registration in your specification as a result of comments on ietf-type (or for any other reason), send the revised version to [media-types@iana.org](mailto:media-types@iana.org).
+   - If you are registering an XML-based format, you may want to cc: [ietf-xml-mime@imc.org](mailto:ietf-xml-mime@imc.org).
+   - Note that you need to be [subscribed to the list](https://www.ietf.org/mailman/listinfo/ietf-types) to post to it.
+   - To make it easier for your WG to track comments on the Media Type section, you may cross-post the comments list for your specification.
+3. In preparation for Candidate Recommendation:
+   
+   - Change the introduction to the registration information to say that it is being submitted to the IESG for review, approval, and registration with IANA.
+   - Fill the [IANA form](https://www.iana.org/form/media-types), listed in [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml). The IANA Services Specialist will check with [Wendy Seltzer](mailto:wseltzer@w3.org) and [Philippe Le Hégaret](mailto:plh@w3.org) to validate the request on behalf ot W3C.
+4. In preparation for Proposed Recommendation and Recommendation:
+   
+   1. Check on progress of registration, first directly at [IANA](https://www.iana.org/assignments/media-types/), and if your type is not yet registered there, contact [iana-mime-comment](mailto:iana-mime-comment@iana.org).
+   1. Update the introduction to the registration information in your specification to say either “registered with IANA at…” or “under review by the IESG…”, as applicable.
+   1. If your registration points to a dated version, request update of the registration via [iana-mime-comment](mailto:iana-mime-comment@iana.org).
+
+W3C Community Groups may also request to register a provisional media type through W3C. All requests for W3C media types submitted to IANA get checked by W3C.
+
+## History of this Document
+
+- Updated in December 2019 to take the IANA form into account. Removed the (unmaintained) list of media types under W3C control.
+- Updated in September 2015 to point to Process 2015.
+- Updated in July 2014 in preparation for the adoption of the 2014 Process, which merged Last Call with Candidate Recommendation. Removed the former process involving registration with an RFC.
+- See [TAG discussion](https://lists.w3.org/Archives/Public/www-tag/2006Aug/0012.html) from August 2006.
+- Status table and new process added, mostly during 2004, by [Martin Dürst](https://www.w3.org/People/D%C3%BCrst/)
+- Created 28 June 2002 by [Joseph Reagle](https://www.w3.org/People/Reagle/)
+

--- a/editor/namespaces.md
+++ b/editor/namespaces.md
@@ -1,5 +1,6 @@
 ---
 title: URIs for W3C Namespaces
+submenu: [publication-policies]
 toc: true
 ---
 

--- a/editor/namespaces.md
+++ b/editor/namespaces.md
@@ -1,0 +1,99 @@
+---
+title: URIs for W3C Namespaces
+toc: true
+---
+
+## Status of this document  {#status}
+
+This document describes the W3C policy for [XML namespace](https://www.w3.org/TR/xml-names11/) allocation in W3C Technical Reports. This document is part a series of documents that describe W3C Technical Report Publication Policies.
+
+Exceptions to this policy **MAY** be authorized by the Director.
+
+## Namespace URIs in Recommendation Track Documents, Group Notes, and other Working Drafts  {#allocation}
+
+Groups **SHOULD** use namespace URIs that have the characteristics of uniqueness.
+
+Director approval is NOT REQUIRED when a namespace URI in a Technical Report has any of the following forms:
+
+- `http://www.w3.org/ns/ssss`
+- `http://www.w3.org/YYYY/MM/ssss`
+- `http://www.w3.org/YYYY/ssss`
+
+where:
+
+- `ns` is the literal string "`ns`"
+- `YYYY` and `MM` are decimal digits corresponding to the year and month of URI allocation
+- `ssss` is a short string not causing confusion, alarm, or embarrassment. For instance, the short string should not cause confusion when used in both `http://www.w3.org/TR/ssss` and `http://www.w3.org/ns/ssss` URIs.
+
+A trailing "`/`" **MAY** be used and does not require Director approval.
+
+The W3C Webmaster allocates and authorizes namespace URIs having the forms listed above. W3C provides the service of allocating and maintaining persistent URIs so that those URIs remain stable during discussions. Allocation does **not** imply any endorsement by W3C of the related specifications. The [W3C URI persistence policy](https://www.w3.org/policies/uri-persistence/) only applies to URIs of the above forms, and does not apply to other URIs within w3.org (e.g., those for lists.w3.org).
+
+Director approval is REQUIRED for all other namespace URIs. In particular:
+
+- The Director **MAY** authorize a group to use a namespace URI that does not begin with `http://www.w3.org/`. The Director expects the organization that allocates the URI to have a clear persistence policy associated with the URI, to make a commitment to longevity of service, and to provide information about how the URI will be maintained in the event of the demise of the host organization.
+
+### Rationale for the http://www.w3.org/YYYY/MM/ssss syntax  {#syntax-rationale}
+
+This syntax enables the W3C support staff to ensure very high level of persistence for namespace URIs, in terms of the non-reuse and the availability of any online materials (schemata etc).
+
+The "`www.w3.org`" is used instead of "`w3.org`" (an internal decision made for the entire site many months ago) because:
+
+- `www.w3.org` is in very common use and cannot be abandoned;
+- to duplicate the site at both addresses would trash the efficiency of caches, indexes and archives all over the world.
+
+The form "`http://www.w3.org/activity/date/foo`" cannot be readily implemented due to the diversity of policies governing each subtree of the W3C site. These policies vary in order to support the diversity of work styles and tools used across the Consortium. Therefore no consistent commitment to persistence can be made in such a sweeping way. Group participants should bear in mind that the W3C Team will be maintaining this Web space long after the groups have become more interested in other topics or have been closed.
+
+## Namespace URIs in Member and Team Submissions  {#submissions}
+
+Some Member and Team Submissions are designed to seed work on the Recommendation Track; others simply provide information or serve other purposes.
+
+In all Member and Team Submissions:
+
+1. Namespace URIs **MUST** be dereferenceable, and
+2. [Namespace Documents](#nsdoc) **MUST** describe the [relationship between the defining specification and the namespace URI](#Policy)
+
+When a Submission is designed to seed work on the Recommendation Track:
+
+1. Namespace URIs **SHOULD** follow the conventions for [Recommendation Track documents](https://www.w3.org/2005/07/13-pubrules-about#rectrack) in order to ease the later transition to the Rec Track. If it does not, the URI publisher **MUST** have clear persistence policy (similar to W3C's, i.e., that the URI publisher will make every effort to service requests for the [Namespace Document](#nsdoc)).
+
+## Namespace Document  {#nsdoc}
+
+A Namespace Document describes the namespace, providing directly or by reference information for human and also, ideally, machine consumption. A Namespace Document is available for retrieval using a corresponding namespace URI.
+
+When a namespace URI appears in a Recommendation Track document, the responsible group **MUST** publish a corresponding Namespace Document. In other contexts as well, groups **SHOULD** publish Namespace Documents. [RDFS](https://www.w3.org/TR/rdf-schema/) and/or [OWL](https://www.w3.org/TR/owl-ref/) are used for RDF namespaces.
+
+## Namespace changes over time  {#Policy}
+
+The [TAG finding](https://www.w3.org/2001/tag/findings) titled [The Disposition of Names in an XML Namespace](https://www.w3.org/2001/tag/doc/namespaceState.html) explains how the use of a particular namespace may evolve over time. At the W3C, it is important for a group to state clearly its expectations for how use of the namespaces it controls will or will not change over time. Groups **SHOULD** document those expectations in \[or clearly linked from] the [Namespace Document](#nsdoc). A draft TAG Finding [Associating Resources with Namespaces](https://www.w3.org/2001/tag/doc/nsDocuments/) provides additional guidance on the creation of such namespace documents. The namespace document could contain text along the following lines:
+
+Example 1
+: The definitions of names in this namespace will not change from those given in the June 13 2007 version of the Foonly spec \[ref. dated URI]. Subsequent versions of the Foonly spec which make any substantive changes will do so in a new namespace.
+
+Example 2
+: This namespace URI will be used to refer to this and future versions of this specification. The specification defines language extension mechanisms and how to handle changes such as the addition of new terms to the language. W3C reserves the right to determine which changes (backward compatible or not) are in the interest of the community at large.
+
+Example 3
+: This namespace URI will only be used to refer to this version of this specification: different URIs will be used for any and all new versions of the specification except as follows: This namespace URI may be reused in any update of the specification which is made for the purpose of clarification or bug fixes. These changes will be minor in that they do not (a) change the meaning or validity of existing documents written using the namespace, or (b) affect the operation of existing software written to process such documents.
+
+Example 4 \[Before CR]
+: Until the specification reaches W3C Candidate Recommendation (CR) status, this namespace URI may be reused by any update in such a way as to cause documents written using the namespace to become invalid or to change in meaning.
+
+Example 5 \[Before CR]
+: Until the specification reaches W3C Candidate Recommendation (CR) status, this namespace URI may be reused in such a way as to affect the operation of existing software written to process documents written according to this specification.
+
+## About this document  {#about}
+
+Discussion of this policy is appropriate in the [uri mailing list](https://lists.w3.org/Archives/Public/uri/) , [www-tag](https://lists.w3.org/Archives/Public/www-tag/), and various other lists.
+
+- 20060906: After [discussion on www-tag](https://lists.w3.org/Archives/Public/www-tag/2006Aug/0081.html) and with support from Director, announced http://www.w3.org/ns/. See [announcement to www-tag on 6 Sep](https://lists.w3.org/Archives/Public/www-tag/2006Sep/0039.html).
+- 20050131: Revision announced to Chairs.
+- 19991026: [First revision](https://www.w3.org/1999/10/nsuri) announced to the Chairs ([announcement](https://lists.w3.org/Archives/Member/chairs/1999OctDec/0019.html)).
+
+More background:
+
+- [This version and latest version URIs](https://www.w3.org/TR/#versioning) are described on the [TR page](https://www.w3.org/TR/).
+- [URI persistence policy](https://www.w3.org/policies/uri-persistence/)
+- [Hugo and Dan on this topic](https://www.w3.org/1999/10/20-namespace-uris) _(Team only)_
+- [Architecture of the World Wide Web](https://www.w3.org/TR/webarch/); see the section on URI persistence
+- ["Cool URIs don't change"](https://www.w3.org/Provider/Style/URI) - TimBL on persistence

--- a/editor/versioning.md
+++ b/editor/versioning.md
@@ -157,4 +157,4 @@ See the [Manual of Style](../manual-of-style/) and the considerations for [norma
 
 ## Namespace Management  {#nsmgt}
 
-It is important to specify clearly the relationship between a Namespace URL and the specification that defines it. Each group should explain that relationship in the defining specification and/or schema; see [URLs for W3C Namespaces](https://www.w3.org/2005/07/13-nsuri) for more information.
+It is important to specify clearly the relationship between a Namespace URL and the specification that defines it. Each group should explain that relationship in the defining specification and/or schema; see [URIs for W3C Namespaces](namespaces.md) for more information.

--- a/editor/versioning.md
+++ b/editor/versioning.md
@@ -1,5 +1,6 @@
 ---
 title: Version Management in W3C Technical Reports
+submenu: [publication-policies]
 toc: true
 ---
 

--- a/editor/versioning.md
+++ b/editor/versioning.md
@@ -1,0 +1,161 @@
+---
+title: Version Management in W3C Technical Reports
+toc: true
+---
+
+## Status of this Document  {#status}
+
+This document is part a series of documents that describe W3C Technical Report Publication Policies.
+
+## Introduction  {#intro}
+
+As W3C has matured, more and more technologies are undergoing major revisions (as seen with "SVG 2.0", "HTML 5.2", "DOM 4.1", "CSP 3", etc.). Working Groups typically find they need to address several high-level versioning issues when starting to revise a Recommendation:
+
+1. What will be the relationship between the Recommendations? Does the new one supersede or outdate the old one or will the two co-exist, each with an appropriate audience? What is the impact of these changes on authors? On implementers?
+1. Should the version number change? What will the marketing impact be of a particular version number change?
+1. What is the impact on XML namespaces defined in one or both specifications?
+1. Beyond the technical issues related to forwards and backwards compatibility, what about the branding and naming issues?
+
+There are also numerous operational issues to consider:
+
+1. What does "Canonical URL" mean when W3C has published Recommendations "1.x" and "2.x" of a technology?
+1. What conventions should a Working Group choose to facilitate future management of multiple versions?
+
+This document provides some rules and guidance on a few of these topics, based on experience with W3C publications. This document is far from an exhaustive treatise on version management; it is intended to help raise awareness about a handful of common W3C publication issues. Please also consult the list of [TAG findings](https://www.w3.org/2001/tag/findings) for discussion of versioning from a technical perspective.
+
+See the [standards FAQ](https://www.w3.org/standards/faq) for information about [this version and latest version URLs](https://www.w3.org/standards/faq#persistence).
+
+## Version Numbers  {#versionnbs}
+
+W3C Working Groups have adopted several approaches to versioning, including:
+
+- Major and minor version numbers (e.g., "SMIL 2.1")
+- Levels ("CSS 3", "DOM 3")
+
+**Note:** Current W3C practice is to reserve the phrase "Nth Edition" for editorial revisions of a Recommendation.
+
+The remainder of this document focuses on the choice of using major and minor version numbers, as this is scheme most groups have adopted.
+
+Branding, magnitude of changes, relationships to other specifications, and other factors have an impact on the choice of version number. Please also note the different classes of change described in [section 6.2.3 of the W3C Process Document](https://www.w3.org/policies/process/#substantive-change). This document does not address all of the factors that go into the choice of a version number. However, one common expectation when using the major/minor version scheme is that, for a given major version number, the Recommendation with the highest minor version number supersedes all others sharing that major version number. By supersede, we mean that authors and implementers should stop using the old version and start using the new version; in effect the new version masks the old one. The status section of a minor version should state clearly that it supersedes the previous minor version.
+
+The expectation that version `N.2` supersedes `N.1` leads to other suggestions in this document. Therefore, if a Working Group does not expect this to be the case for their documents, they should contact the Communications Team.
+
+Please recall that W3C's persistence policy ensures that a superseded document will always be identifiable by its "This version URL".
+
+### Tracking Version Numbers  {#tracking}
+
+Each W3C technical report includes several URLs to make it easier for readers to track the evolution of a specification. There are other ways to find information about W3C technical reports, including on the W3C [Technical Reports index](https://www.w3.org/TR/), on Working Group pages, and through a search engine. The URL with shortnames has proved a useful companion to the "This (dated) version URL".
+
+In the linear world of a document series that starts with a First Public Working Draft and ends with a Recommendation, it is easy to understand the semantics of a "Latest version URL". When a Working Group is managing multiple versions of a specification in parallel, some clarification is required. When a "Latest version URL" appears in an "ExampleML 2.0" specification, does the URL identify the latest version of ExampleML? of ExampleML 2.x? of ExampleML 2.x Recommendation? Something else?
+
+The following proposal -- for multiple "Latest version URLs" -- strikes a balance between brevity in the document front matter and useful additions to help readers find important resources. This proposal will not address the needs of all readers or users of a specification. We therefore encourage Working Groups to advise readers (e.g., in the status section, or in the section on changes) to consult the Working Group's public pages for the complete revision history of related specifications.
+
+### Versioned URL Semantics  {#versioned-urls}
+
+W3C recommends that groups use the following versioned URLs: For a set of minor versions that are part of the same major version branch, one URL designates the most recent minor version, whatever its maturity level (Working Draft, Recommendation, etc.). The label for this URL should be "`Latest [Acronym] 1 version`", as in "`Latest ExampleML 1 version`".
+
+We recommend this syntax for version number URLs:
+
+`/TR/<shortname-N>` (or `/TR/<shortnameN>`)
+
+Those versioned URLs provides quick access to the latest work within a given major version. `N` is a number, not interpreted by the underlying system except for its sequence order. You may use for example `2`, `2.0`, `2018`.
+
+When a Working Group follows this scheme, Director approval of new version number is not required.
+
+Working Groups wishing to adopt this scheme even though they already have allocated their short name should contact webreq@w3.org.
+
+Here is an example of how W3C manages these URLs over time.
+
+|  | ExampleML 1.0 WD published | ExampleML 1.0 REC published | ExampleML 1.1 WD published | ExampleML 1.1 REC published | ExampleML 2.0 WD published | ExampleML 2.0 REC published |
+|---|---|---|---|---|---|---|
+| **"Latest ExampleML 1" URL identifies** | ExampleML 1.0 WD | ExampleML 1.0 REC | ExampleML 1.1 WD | ExampleML 1.1 REC | ExampleML 1.1 REC | ExampleML 1.1 REC |
+| **"Latest ExampleML 2" URL identifies** | N/A | N/A | N/A | N/A | ExampleML 2.0 WD | ExampleML 2.0 REC |
+
+
+Some groups have suggested that additional latest version URLs may help them manage their work. For instance, some Working Groups would like to use "latest minor version" URLs while working towards a new Recommendation. We advise against "latest minor version URLs" because their utility is short-lived, in light of the premise that minor versions supersede one another. For example, as soon as the ExampleML 1.2 is published, the "latest ExampleML 1.1 URL" will become a dead-end; one will not be able find the new 1.2 minor version directly from the 1.1 version. Rather than publish "latest minor version URLs", we recommend simply using the group's home page to track the latest draft of a minor version.
+
+## Short Names and canonical URLs  {#shortnames}
+
+For each set of specifications, a URL designates the most relevant of a given technology, whatever the major version number. The label for this URL should be "Canonical URL".
+
+We use this syntax for those URLs:
+
+`/TR/<shortname>/`
+
+As an example, see the [HTML specification](https://www.w3.org/TR/html/) which uses `/TR/html/`.
+
+The canonical URL designates the most relevant specification approved by a Group for a given technology. It may designate the most mature Recommendation of a given technology or the most agreeing-on version depending on the choices of the Group. The label for this URL should be "Canonical URL".
+
+In practice, this "Canonical URL" returns the document provided in [Latest URLs](#latest) or in [Upcoming URLs](#upcoming). Working Groups wishing to pick their most relevant specification for the purpose of this "Canonical URL" should contact webreq@w3.org.
+
+### Alternative canonical URLs
+
+The "Canonical URL" and the version numbers dp not address all of the needs that go into the choice of a link for a technology. Consequently, several URLs are created automatically based on the "Canonical URL".
+
+#### Latest URLs  {#latest}
+
+"Latest" will return the most "stabilized" document available. We use this syntax for those URLs:
+
+`/TR/<shortname>/latest/`
+
+For example, [`/TR/CSP/latest/`](https://www.w3.org/TR/CSP/latest/) points to the latest Recommendation for CSP.
+
+More precisely, the algorithm to determine this URL will return the **first document** found in the following ordered list:
+
+1. the **highest** level being a CR, an Edited CR, a PR, an Edited PR
+1. a REC that is not obsolete/superceded/rescinded/retired/outdated
+1. the **highest** level being a Note if not retired
+1. the **lowest** level being a WD
+1. the obsolete/superceded/rescinded REC
+1. the retired Note
+
+#### Upcoming URLs  {#upcoming}
+
+"upcoming" will return the "tip" document agreed by the Group. We use this syntax for those URLs:
+
+`/TR/<shortname>/upcoming/`
+
+For example, [`/TR/CSP/upcoming/`](https://www.w3.org/TR/CSP/upcoming/)
+
+As such, it points to the **first document** found in the following ordered list:
+
+1. the **highest** level that is not obsolete/superceded/rescinded/retired/outdated
+1. the obsolete/superceded/rescinded/retired document
+
+#### Editor drafts URLs  {#ed}
+
+**If provided in the published document**, those URLs will redirect to the editor's draft of the upcoming document, which may or may not have review from the Working Group. We use this syntax for those URLs:
+
+`/TR/<shortname>/ed/`
+
+For example, [`/TR/CSP/ed/`](https://www.w3.org/TR/CSP/ed/) redirects to `https://w3c.github.io/webappsec-csp/`.
+
+If the editing workmode of your Group guarantees its agreement to the content of the editor draft (this is the case if your Group uses a pull request review process), we highly recommend **at the minimum** that the document be automatically published to ensure that the editor draft URLs and the [Upcoming URLs](#upcoming) return the same main content. An even better approach in such case is to redirect the "editor draft URL" to the "Upcoming URL" (this avoids returning 404 on the editor draft URL).
+
+#### Example  {#example}
+
+CSP1 is a Working Group Note. CSP2 is a Recommendation. CSP3 is a Working Draft. This would imply the following URLs:
+
+- `/TR/CSP1/` returns the CSP1 Working Group Note
+- `/TR/CSP2/` returns the CSP2 Recommendation
+- `/TR/CSP3/` returns the CSP3 Working Draft
+- `/TR/CSP/upcoming/` returns the same document as `/TR/CSP3/`
+- `/TR/CSP/latest/` returns the same document as `/TR/CSP2/`
+- `/TR/CSP/` returns the same document as `/TR/CSP/upcoming/` (since the Working Group favors the "tip")
+- `/TR/CSP/ed/` redirects to the CSP3 editor draft, ie `https://w3c.github.io/webappsec-csp/`
+
+## Dated URLs and outdating  {#dated}
+
+W3C is automatically outdating a dated document if it is used as a previous version link from a more recent one. This allows the community to be aware that they're potential looking at an old draft. For example, see the [W3C Working Draft, 1 September 2016 for CSP3](https://www.w3.org/TR/2016/WD-CSP3-20160901/).
+
+## URLs and Normative References  {#normative}
+
+At this time (read: we know this is suboptimal nowadays), we still recommend that you **not** create normative references from a W3C Recommendation to resources (published inside or outside W3C) that are likely to change over time and where those changes might affect the meaning of, or conformance to, the W3C Recommendation. It follows that if you wish to create a normative reference to a W3C technical report, you should use a "this version" URL instead of a canonical URL (or their alternative forms).
+
+In general, if the Working Group has expectations about the evolution of a normative reference (however it is identified), the group should state those expectations in prose in the technical report.
+
+See the [Manual of Style](../manual-of-style/) and the considerations for [normative references](../process/tilt/normative-references.md) for additional discussion of references to resources that change over time and when references to these resources are are appropriate.
+
+## Namespace Management  {#nsmgt}
+
+It is important to specify clearly the relationship between a Namespace URL and the specification that defines it. Each group should explain that relationship in the defining specification and/or schema; see [URLs for W3C Namespaces](https://www.w3.org/2005/07/13-nsuri) for more information.

--- a/editor/versioning.md
+++ b/editor/versioning.md
@@ -23,8 +23,6 @@ There are also numerous operational issues to consider:
 
 This document provides some rules and guidance on a few of these topics, based on experience with W3C publications. This document is far from an exhaustive treatise on version management; it is intended to help raise awareness about a handful of common W3C publication issues. Please also consult the list of [TAG findings](https://www.w3.org/2001/tag/findings) for discussion of versioning from a technical perspective.
 
-See the [standards FAQ](https://www.w3.org/standards/faq) for information about [this version and latest version URLs](https://www.w3.org/standards/faq#persistence).
-
 ## Version Numbers  {#versionnbs}
 
 W3C Working Groups have adopted several approaches to versioning, including:

--- a/index.md
+++ b/index.md
@@ -72,7 +72,7 @@ toc: true
   - Considerations for [joint deliverables](process/joint-deliverables.md)
   - [Transition requirements](transitions/) for all W3C maturity levels (First Public Draft, CR, PR, REC, etc.). Try also our [step finder](transitions/nextstep.html) and look at [milestones calculator](https://w3c.github.io/spec-releases/milestones/).
   - [Request Wide Review](documentreview/) at least *2-3 months before CR*, to allow time for discussion and rework. This includes requesting [horizontal reviews](documentreview/#how-to-get-horizontal-review).
-  - [Pubrules](https://www.w3.org/pubrules/) ([publication requirements](https://www.w3.org/pubrules/doc)) and links to related policies (e.g., [namespaces](https://www.w3.org/2005/07/13-nsuri), [MIME type registration](https://www.w3.org/2020/01/registering-mediatypes), [version management](https://www.w3.org/2005/05/tr-versions), and [in-place modifications](standards-track/republishing.md))
+  - [Pubrules](https://www.w3.org/pubrules/) ([publication requirements](https://www.w3.org/pubrules/doc)) and links to related policies (e.g., [namespaces](editor/namespaces.md), [Media type registration](editor/mediatypes.md), [version management](editor/versioning.md), and [in-place modifications](standards-track/republishing.md))
     See also [Pubrules issue management](https://github.com/w3c/specberus/issues)
   - **March 2017**: [Obsoleting and Rescinding W3C Specifications](process/obsolete-rescinded-supserseded.md)
 - [Normative References](process/tilt/normative-references.md); considerations the Team takes into account when evaluating normative references

--- a/index.md
+++ b/index.md
@@ -72,7 +72,7 @@ toc: true
   - Considerations for [joint deliverables](process/joint-deliverables.md)
   - [Transition requirements](transitions/) for all W3C maturity levels (First Public Draft, CR, PR, REC, etc.). Try also our [step finder](transitions/nextstep.html) and look at [milestones calculator](https://w3c.github.io/spec-releases/milestones/).
   - [Request Wide Review](documentreview/) at least *2-3 months before CR*, to allow time for discussion and rework. This includes requesting [horizontal reviews](documentreview/#how-to-get-horizontal-review).
-  - [Pubrules](https://www.w3.org/pubrules/) ([publication requirements](https://www.w3.org/pubrules/doc)) and links to related policies (e.g., [namespaces](https://www.w3.org/2005/07/13-nsuri), [MIME type registration](https://www.w3.org/2020/01/registering-mediatypes), [version management](https://www.w3.org/2005/05/tr-versions), and [in-place modifications](https://www.w3.org/2003/01/republishing/))
+  - [Pubrules](https://www.w3.org/pubrules/) ([publication requirements](https://www.w3.org/pubrules/doc)) and links to related policies (e.g., [namespaces](https://www.w3.org/2005/07/13-nsuri), [MIME type registration](https://www.w3.org/2020/01/registering-mediatypes), [version management](https://www.w3.org/2005/05/tr-versions), and [in-place modifications](standards-track/republishing.md))
     See also [Pubrules issue management](https://github.com/w3c/specberus/issues)
   - **March 2017**: [Obsoleting and Rescinding W3C Specifications](process/obsolete-rescinded-supserseded.md)
 - [Normative References](process/tilt/normative-references.md); considerations the Team takes into account when evaluating normative references

--- a/index.md
+++ b/index.md
@@ -180,7 +180,7 @@ toc: true
 
 - Most popular editing tools: [Bikeshed](https://speced.github.io/bikeshed/), [respec](https://github.com/speced/respec/wiki)
 - [W3C Manual of Style](manual-of-style/)
-- [Tips for getting to Recommendation faster](https://www.w3.org/2002/05/rec-tips)
+- [Tips for getting to Recommendation faster](standards-track/rec-tips.md)
 
 ### GitHub {#GitHub}
 

--- a/manual-of-style/index.html
+++ b/manual-of-style/index.html
@@ -1487,7 +1487,7 @@ https://lists.w3.org/Archives/Public/www-html-editor/2000JanMar/0103.</dd>
 <dt id="ref-REGISTER-1">[REGISTER-1]</dt>
 
 <dd><a href=
-""https://www.w3.org/guide/editor/mediatypes">Register an Internet Media Type for a W3C Specification</a>, Philippe Le Hégaret, 2019. This Web page is on-line at
+"https://www.w3.org/guide/editor/mediatypes">Register an Internet Media Type for a W3C Specification</a>, Philippe Le Hégaret, 2019. This Web page is on-line at
 "https://www.w3.org/guide/editor/mediatypes.</dd>
 
 <dt id="ref-REGISTER-2">[REGISTER-2]</dt>

--- a/manual-of-style/index.html
+++ b/manual-of-style/index.html
@@ -1049,7 +1049,7 @@ warning about:</p>
 
 <ul>
 <li>For information about defining a new Internet media type (formerly known as <abbr title="Multipurpose Internet Mail Extensions">MIME</abbr> type) in your specification, see <cite><a href=
-"https://www.w3.org/2002/06/registering-mediatype">How to Register an Internet Media Type for a W3C Specification</a></cite> [<cite><a href="#ref-REGISTER-1">REGISTER-1</a></cite>].</li>
+"https://www.w3.org/guide/editor/mediatypes">Register an Internet Media Type for a W3C Specification</a></cite> [<cite><a href="#ref-REGISTER-1">REGISTER-1</a></cite>].</li>
 
 <li>For information about referring to existing Internet media types (registered or not), see the email message <cite><a href=
 "https://lists.w3.org/Archives/Public/www-tag/2006Aug/0012">TAG Position on Use of Unregistered Media Types in W3C Recommendations</a></cite> [<cite><a href="#ref-REGISTER-2">REGISTER-2</a></cite>].</li>
@@ -1487,8 +1487,8 @@ https://lists.w3.org/Archives/Public/www-html-editor/2000JanMar/0103.</dd>
 <dt id="ref-REGISTER-1">[REGISTER-1]</dt>
 
 <dd><a href=
-"https://www.w3.org/2020/01/registering-mediatypes">How to Register an Internet Media Type for a W3C Specification</a>, Philippe Le Hégaret, 2019. This Web page is on-line at
-https://www.w3.org/2020/01/registering-mediatypes.html.</dd>
+""https://www.w3.org/guide/editor/mediatypes">Register an Internet Media Type for a W3C Specification</a>, Philippe Le Hégaret, 2019. This Web page is on-line at
+"https://www.w3.org/guide/editor/mediatypes.</dd>
 
 <dt id="ref-REGISTER-2">[REGISTER-2]</dt>
 

--- a/process/adv-notice.md
+++ b/process/adv-notice.md
@@ -66,7 +66,7 @@ The [Process Document requirements](https://www.w3.org/policies/process/#WGChart
 Hence the sentence in the Process Document:
 > Advisory Committee representatives MAY provide feedback on the Advisory Committee discussion list or via other designated channels.
 
-These ideas are further discussed in [Tips for Getting to Recommendation Faster](https://www.w3.org/2002/05/rec-tips),
+These ideas are further discussed in [Tips for Getting to Recommendation Faster](../standards-track/rec-tips.md),
 in particular:
 
 > When a Charter is proposed to the Advisory Committee, garner support from fellow W3C Members on w3c-ac-forum. When there is substantial support for new work among the Members, the Team may create a special mailing list for discussion among Members and Team about Group charter development. Start discussions with proposals, calendars, statements of expected resource commitments, and other such signals.

--- a/process/charter.md
+++ b/process/charter.md
@@ -30,7 +30,7 @@ Within the Team, the *Strategy Team* manages the charter development process, in
 These are the recommended steps for any party preparing a charter for a new Working Group or Interest Group:
 
 Check readiness
-: For a Working Group charter, review: [W3C Recommendation Track Readiness Best Practices](../standards-track/), [Tips for Getting to Recommendation Faster](https://www.w3.org/2002/05/rec-tips), and [How to transition work from a Community Group to a Working Group](cg-transition.md).
+: For a Working Group charter, review: [W3C Recommendation Track Readiness Best Practices](../standards-track/), [Tips for Getting to Recommendation Faster](../standards-track/rec-tips.md), and [How to transition work from a Community Group to a Working Group](cg-transition.md).
 
 Draft charter
 : Use the [charter template](https://w3c.github.io/charter-drafts/charter-template.html) to create a draft charter, ideally on GitHub. This is where substantive discussion of the charter should take place, including issues and pull requests. **Note:** There are ongoing discussions about making it easier for people to find draft charters, e.g., by using a single GitHub repo for all draft charters.

--- a/process/closing-wg-implementation.md
+++ b/process/closing-wg-implementation.md
@@ -56,6 +56,7 @@ The Contact:
 
 The Comm team:
 
-- Closes the [group(s)](https://www.w3.org/admin/) by setting their \[2024-Jun change:] instead of a checkbox, the boolean is replaced by a date picker. The WG/IG closing dates are available as an API data point.
-- (The above automatic moves the group(s) from [the public list of groups](https://www.w3.org/groups/) to the list of closed groups.)
+- Closes the [group(s)](https://www.w3.org/admin/) by setting their `Closed Date`. The WG/IG closing dates are available as an API data point.
+
+   This automaticly moves the group(s) from [the public list of groups](https://www.w3.org/groups/) to the list of closed groups.
 

--- a/process/closing-wg-implementation.md
+++ b/process/closing-wg-implementation.md
@@ -1,0 +1,61 @@
+---
+title: How to close a work Group - Implementation
+toc: true
+---
+
+_This is the Team documentation detailing the various steps when [closing a group](closing-wg.md)._
+
+## Group Successfully Completed  {#success}
+
+- Relevant Contact raises awareness to TiLT. Awareness includes:
+  
+  - Short assessment of success
+  - Status of any Rec-track work that has not completed
+  - Next steps
+- TiLT approves closure
+- Relevant Contact notifies the Group (preferably using its publicly available mailing list).
+- Relevant Contact works with Comm Team by writing a draft closure announcement to w3t-comm (you may use the [template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2F&template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fgroup-closed.html&submit=Continue...)).
+- Comm Team sends announcement to w3c-ac-members, cc: chairs@w3.org and the Working Group's mailing-list(s) \[so there is a breadcrumb in the group's archive(s)]; and then [implements closure on the Web site](#after)
+
+## Group Under-resourced, Unsuccessful, Detrimental or Finished Early  {#unsuccessful}
+
+- TAG, AB, or Relevant Contact raises awareness to TiLT. Awareness includes:
+  
+  - Short assessment of reasons for failure
+  - Status of any Rec-track work that has not completed
+  - Next steps
+- TiLT starts [AC Review of proposed group closure](https://www.w3.org/policies/process/#GeneralTermination).
+- TiLT approves closure
+- Relevant Contact notifies the Group (preferably using its publicly available mailing list).
+- Relevant Contact works with Comm Team by writing a draft closure announcement to w3t-comm (you may use the [template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2F&template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fgroup-closed.html&submit=Continue...)).
+- Comm Team sends announcement to w3c-ac-members, cc: chairs@w3.org and the Working Group's mailing-list(s) \[so there is a breadcrumb in the group's archive(s)]; and then [implements closure on the Web site](#after)
+
+**Note:** In the case of a controversial closure, W3M MAY opt to give the Advisory Committee the opportunity to respond to a *proposal to closure*.
+
+## Implementing the Closure  {#after}
+
+The Contact:
+
+- Requests publication of any WD, CR, PR, PER as terminating Notes. The document is *very short* with any rationale in the status. (Alternatively, it is also possible for the Webmaster to mark documents as obsolete without republication, but this is an inferior approach. The "stub" approach is intended to be lightweight and address long-term goals of useful "latest version" URIs.)
+- Ensures the group's home page indicates that it is closed. Point people to useful pages for more information or next steps;
+- Modify the group's charter: end date, a pointer to a closure announcement to the group's mailing list (usually from the public archive);
+- Identifies related groups (e.g. Chairs group, Coordination Group) that should be closed by the Comm team;
+- Updates any relevant mailing list archives with the [List Archive Customizer](https://lists.w3.org/admin/customize) with updated archive header information indicating that the list used to be the list for the Foo WG (with a link);
+- Is the mailing list to be kept open following the closure of the group? If so:
+  
+  1. Obtain a copy of the subscribers who were subscribed to the list due to their membership in the group, by copying the addresses listed in the 'Non auto removable' portion of the subscriber list on the [list admin page](https://lists.w3.org/admin/manage) for the list in question.
+  1. Add that list of addresses to the 'Distribution auto removable' portion of the distribution list by copying it into the textarea at the bottom and submitting the form.
+  1. [Ask the Systems Team](mailto:sysreq@w3.org) to dissociate the DB group from the mailing list.
+- If the list is to be closed:
+  
+  1. Deactivate the mailing list via the [list admin page](https://lists.w3.org/admin/manage) *"deactivate this list"* menu entry;
+  1. If you would like a custom autoreply to be sent back instead of the generic one, [write to sysreq](mailto:sysreq@w3.org?subject=custom%20autoreply%20for%20LIST-NAME) and provide text that informs people where the discussion has moved.
+- If the WG has a wiki, contact systeam if the wiki should be archived (closed for good).
+- Should contact systeam in case of issues.
+- Update [FTEMS](https://www.w3.org/2005/09/manage/Overview.php3?uastate=showuas) to reflect the change, in coordination with the Function lead.
+
+The Comm team:
+
+- Closes the [group(s)](https://www.w3.org/admin/) by setting their \[2024-Jun change:] instead of a checkbox, the boolean is replaced by a date picker. The WG/IG closing dates are available as an API data point.
+- (The above automatic moves the group(s) from [the public list of groups](https://www.w3.org/groups/) to the list of closed groups.)
+

--- a/process/closing-wg.md
+++ b/process/closing-wg.md
@@ -31,4 +31,4 @@ A proposal to close a Group before the end of its chartered term must be explain
 
 Note that, if the Group has Recommendation-track specifications in development, and they have not yet reached W3C Recommendation status, closing the group [terminates Disclosure Obligations](https://www.w3.org/policies/patent-policy/#sec-disclosure-termination) for those specifications.
 
-_See the Team documentation of the [detailed steps for closing a group.](closing-group-implementation.md)_
+_See the Team documentation of the [detailed steps for closing a group.](closing-wg-implementation.md)_

--- a/process/closing-wg.md
+++ b/process/closing-wg.md
@@ -3,15 +3,15 @@ title: How to close a work Group
 toc: yes
 ---
 
-## 1. Introduction {#intro}
+## Introduction {#intro}
 
 The W3C Process describes the [lifecycle of chartered groups](https://www.w3.org/policies/process/#group-lifecyle). At a high level, W3C closes a work Group once it has completed its work.
 
-## 2. Normal closure {#normal}
+## Normal closure {#normal}
 
 Sometimes, after successful completion, the Group is left open to perform **maintenance**; other times, it is closed and a Community Group performs this function.
 
-## 3. Early closure {#early}
+## Early closure {#early}
 
 Exceptionally, a group may be closed before it has completed its work:
 
@@ -31,4 +31,4 @@ A proposal to close a Group before the end of its chartered term must be explain
 
 Note that, if the Group has Recommendation-track specifications in development, and they have not yet reached W3C Recommendation status, closing the group [terminates Disclosure Obligations](https://www.w3.org/policies/patent-policy/#sec-disclosure-termination) for those specifications.
 
-There is *Team-only* documentation of the [detailed steps for closing a group.](https://www.w3.org/2003/04/closing-group.html)
+_See the Team documentation of the [detailed steps for closing a group.](closing-group-implementation.md)_

--- a/process/election.md
+++ b/process/election.md
@@ -1,0 +1,187 @@
+---
+title: How to organize an Advisory Board or Technical Architecture Group election
+toc: true
+---
+
+> The Advisory Board and a portion of the Technical Architecture Group are elected by the Advisory Committee. The election process begins when the Team sends a call for nominations to the Advisory Committee...  
+> - [Section 3.3.3.3 "Advisory Board and Technical Architecture Group Elections"](https://www.w3.org/policiies/process/#AB-TAG-elections) of the Process Document.
+
+This document explains in detail how the Team organizes AB and TAG elections. As explained in the Process Document, TAG terms begin on 1 February and AB terms begin on 1 July.
+
+## Summary of steps  {#summary}
+
+1. Team determines whose seats are up for election or appointment (team-internal)
+   
+   - For AB: 15 February
+   - For TAG: 31 August.
+1. Advance notice of nominations
+   
+   - For AB: 1 March
+   - For TAG: mid-September (4 weeks before nomination)
+1. [Call for nominations](#nominations)
+   
+   - For AB: 1 April
+   - For TAG: the Tuesday nearest to 10 October (between 7-13 October, for 4 weeks)
+1. [Call for votes](#votes)
+   
+   - For AB: 1 May
+   - For TAG: the Tuesday following the end of the Call for nominations (between 11-17 November, for 4 weeks)
+1. [Announce results](#announce) (about three weeks before terms start)
+   
+   - For AB: 7 June (for 1 July term start date)
+   - For TAG: the Tuesday following the end of the voting period (for 1 February term start date).
+1. [The Team Appointment(s)](https://www.w3.org/policiies/process/#TAG-appointments)
+   
+   - The Team will make appointment(s) once the results of the elections are known.
+1. [Welcome new participants](#welcome)
+1. [Thank departing participants](#departing)
+
+The Comm Team prepares announcements, tracks reviews, and publishes the appropriate documents.
+
+2021-02-18: Note on the TAG election period: The W3C Process Community Group raised the [TAG nomination and election period at poor times of the year](https://github.com/w3c/process/issues/487) as an issue. By adjusting the 9-week nominations and elections between 7-13 October and 9-15 December depending on the year, the US Thanksgiving takes place in the middle of the election - but not at the very end of the election and the election completes before the major December vacations.
+
+## Call for nominations  {#nominations}
+
+1. One form for AC Representatives ([sample](https://www.w3.org/2002/09/wbs/33280/tag-201411/) and see below for summary of [information in a nomination form](#nomination-info))
+   
+   - **April 2015 update:** Include information on the nomination form, so that the candidate has more context for what they're writing as *statement*, e.g. link to past public statements. The form should set the expectation that statements are sent to the AC as part of the Call for Votes and is the candidate's biggest chance to communicate.
+   - **January 2021 update:** The announcement and form includes guidance on considering diversity when proposing people to run in the election.
+1. One from for nominees ([sample](https://www.w3.org/2002/09/wbs/1/tagnom-201411/))
+   
+   - At each election, make sure to update the link in the AC form (last section) that refers to the nominee form.
+   - **April 2015 update:** Because there is no IPP form for joining the TAG, the team needs to gather commitments via a WBS form. The appointee(s) should fill out the most recent of the nominee forms.
+1. [Sample of email sent to AC](https://lists.w3.org/Archives/Member/w3c-ac-members/2014AprJun/0000.html)
+
+### During the nomination period
+
+1. WBS automatically sends a reminder to the AC (e.g., one week prior to nomination period end)
+1. Track nominations. In the 2002 nomination period, we received some nominations without comments on the nominees, so we asked the nominees to provide us with text. When it seems like a nominee may not be aware of having been nominated, contact that person.
+1. Double-check whether any [related Members](https://lists.w3.org/Archives/Member/relation-disclosure/) have both sent nominations.
+1. **2022-12-15 Update** ([member-only link](https://github.com/w3c/AB-memberonly/issues/142)): To respect the value of transparency and allow sufficient time to stabilize nomination statements, AB agreed on the common practice for AB and TAG elections, as follows:
+   
+   - During the nomination period: All nominations (e.g., who nominates whom) will be made available publicly on a rolling basis.
+   - When the nomination period ends: All nomination statements will be collectively publicized and further edits to the statements may not be allowed.
+
+### Note: Single "nominator"
+
+There should be a single "nominator." In case there are more than one, the nominee should choose which nomination to accept, probably talking with the nominators. Other nominators are free to endorse the nominee \[for example in w3c-ac-forum conversation].
+
+## Call for votes  {#votes}
+
+- [STV Meeks](https://en.wikipedia.org/wiki/Meek%27s_method) used as Tabulation system; [OpenSTV 1.7](https://github.com/Conservatory/openstv) used to perform the computation.
+- One form for AC Representatives ([sample](https://www.w3.org/2002/09/wbs/33280/tag-20141201/) and summary of [information in a call for votes form).](#cfv-info)
+- [Sample of email sent to AC](https://lists.w3.org/Archives/Member/w3c-ac-members/2014OctDec/0045.html).
+
+During AB and TAG elections, it is appropriate for candidates to campaign and for AC Representatives to discuss candidates positions on various issues on w3c-ac-forum ([archive](https://lists.w3.org/Archives/Member/w3c-ac-forum/)).
+
+**Note:** The team ensures that each candidate may post to and receive email from w3c-ac-forum@w3.org during the election period.
+
+### Using RFC3797  {#using-rfc3797}
+
+1. To prepare for using RFC3797, include the following information to resolve ties:
+   
+   1. Reference date (usually, the day the election ends). **NOTE:** Do not choose a weekend day.
+   1. Three sources of randomness.
+      
+      - Ensure that the sources are *very precisely identified* (e.g., which S&P 500 price index, which Numbers game draw since there may be more than one on the day, how values will be formatted)
+      - Make sure the sources still exist if you are reusing sources from the previous election
+   1. Order of names:
+      
+      - In case of a tie, indicate that the order is that specified in the email, only for those who tied.
+1. In case of a tie, RFC3797 reorders names, after which, available seats are filled in that order (i.e., first person gets a seat, etc.). In the case of a tie among those eligible for a short term: after all elected individuals have been identified, when N people are eligible for M (less than N) short terms. In this case, only the names of those N individuals are provided as input to the procedure. The short terms are assigned in result order.
+1. You can use the [online RFC3797 calculator](https://www.gerv.net/hacking/vrs/) to calculate results after the election. An ordered list of three specific sources of randomness to use:
+   
+   - [Standard & Poor's 500 index](https://www.spglobal.com/spdji/en/indices/equity/sp-500/) for the reference day: e.g., 6,101.24
+   - [Massachusetts Lottery "Numbers" game](https://www.masslottery.com/games/lottery/numbers-game.html) for the reference day: e.g., 8.4.7.0
+   - [Sea Level Pressure in Hg in San Jose, California](https://www.wunderground.com/history/daily/KSJC/date/2001-12-6) for the reference day: e.g., 30.36
+
+### During the vote period
+
+1. WBS automatically sends a reminder to the AC (e.g., one week prior to voting period end)
+1. On the date announced in the call for votes, gather the data for the RFC3797 calculation.
+1. Double-check whether any [related Members](https://lists.w3.org/Archives/Member/relation-disclosure/) have both sent votes.
+1. Once an election has closed, re-sort the candidates on the nominations page alphabetically by family name.
+
+## Announce the election results  {#announce}
+
+1. The shortest incomplete term is assigned to the elected candidate ranked lowest by the tabulation of votes, the next shortest term to the next-lowest ranked elected candidate, and so on. In the case of a tie among those eligible for a short term, we use RFC3797 to resolve the tie as described above.
+1. Update group home pages with new participants and data about length of terms. This makes it easier for everyone to remember who is up for election in a year. Update the group in the DB as well ([TAG](https://www.w3.org/admin/othergroups/34270/edit), [AB](https://www.w3.org/admin/othergroups/7756/edit)). Typically we update this information before the announcement so that the newly elected participants receive the mail. We also tend to leave both new and departing participants in the database until the next face-to-face meeting, as a transition period.
+1. As a personal courtesy, notify candidates (in the case of both outcomes) by email 24h to 2h before the official announcement. Make it clear this is to be kept confidential until results are released.
+1. Announce results to w3c-ac-members. Indicate:
+   
+   - Names of winners.
+   - Names of people who tied.
+   - Names of people who got short terms.
+   - Results of RFC3797 calculations, if any.
+   - Term start date.
+   - List continuing participants.
+   - Do **not** report the number of votes for each candidate.
+1. Announce election results on the W3C Home page ([sample](https://www.w3.org/news/2015/w3c-advisory-committee-elects-technical-architecture-group-2/)).
+1. It is customary for the CEO to contact each departing candidate to thank them for participating.
+
+## Welcome new participants  {#welcome}
+
+1. Have Chair send welcome message to new participants cc the group telling them about access, next meeting.
+1. Add new people / remove departing people from the group in the DB: ([TAG](https://www.w3.org/admin/othergroups/34270/edit), [AB](https://www.w3.org/admin/othergroups/7756/edit)). As of June 2023 the [AB requests](https://lists.w3.org/Archives/Group/ab/2023AprJun/0219.html) that new people be added as soon as the election results are announced. Check with the TAG as to their preference. This gives them ACL access rights and subscribes them to mailing lists. **Note:** Generally, departing participants and new participants should both attend the next face-to-face meeting. After that meeting, unsubscribe departing participants from list, and for the AB, remove them from the ACL group, the [Member AB home page](https://www.w3.org/Member/Board/), and move them to the "Alumni" section of the [public AB home page](https://www.w3.org/2002/ab/).
+
+## Departing Participants  {#departing}
+
+- Per resolution from the AB ([2019-11-20](https://www.w3.org/2019/11/20-ab-minutes.html#item07)), **past members of the AB are given read and write access to w3c-ac-forum at the discretion of the CEO**.
+  
+  - The Comm Team adds departing participants to the [AB alumni group in the DB](https://www.w3.org/admin/othergroups/145687/show), which is subscribed to w3c-ac-forum
+  - ... and informs the CEO that this has been done.
+  - (Then, if the CEO has not already concluded that the AB alum wants and expects this to have been done, the CEO can ex-post-facto confirm with said alum that this has been done and (thereby) give them the opportunity to decline.)
+- The Comm Team prepares certificates to recognize departing participants.
+
+## Appendix  {#appendix}
+
+### Information in WBS Nomination Forms  {#nomination-info}
+
+1. End date and time (23:59 ET) of nomination period, usually **4 weeks**.
+1. Instruction to send nominations to board-nomination@w3.org. There is an auto-responder set up for this list; adjust as necessary.
+1. Number of seats up for election (and who holds them currently). Also, list names of people whose terms are not ending.
+1. Each AC representative may nominate **one person**. Nominees **must** be informed of their nomination.
+1. Specify the minimum and maximum number of available seats:
+    
+    - In the case of regularly scheduled elections of the **TAG**, the minimum and maximum number of available seats are the same: the 4 seats of the terms expiring that year, plus the number of other seats that are vacant or will be vacant by the time the newly elected members take their seats. For N available seats:
+      
+      - If exactly N people are nominated, those individuals are thereby elected.
+      - If more than N are nominated, we will organize an election.
+      - If fewer than N are nominated, we will renew the nomination period for a fixed duration.
+    - In the case of regularly scheduled elections of the **AB**, the minimum and maximum number of available seats differ: The maximum (N) number is the 5 or 6 seats of the terms expiring that year, plus the number of other seats that are vacant or will be vacant by the time the newly elected members take their seats; the minimum (M) number is such that when added to the occupied seats from the prior year, the minimum size of the AB (9) is reached. For N available seats:  
+      
+      - If M-N people are nominated, those individuals are thereby elected.
+      - If more than N are nominated, we will organize an election.
+      - If fewer than M are nominated, we will renew the nomination period for a fixed duration.
+1. Term start date and duration of terms (may be one or two years in order to stagger).
+1. A nominee must be nominated by an AC representative (who can be a candidate). Nominees need not be employees of a Member organization. Nominations must be made with the agreement of the nominee, and should include a short statement about the nominee. These statements are made available to the Membership and the public whether or not there is an election.
+1. Ask for nominee contact information (to be kept Team-confidential): email and phone numbers.
+1. For the TAG: ask for information required by section 3.3.3.3 of the Process Document
+1. Reminder of participation criteria, for example:
+    
+    Please recall that participants on the AB, while representing their company, are expected to perform their duties as unbiased representatives of the W3C community. The participation commitment for the \[AB or TAG] includes \[adjust this accordingly]:
+    
+    1. a weekly teleconference
+    1. three to four face-to-face meetings per year
+    1. participation in group mailing list discussions
+    1. participation at AC meetings and Technical Plenary meetings (encouraged, but not required):
+1. Date of next scheduled face-to-face meeting. Nominees should be prepared to attend that meeting.
+1. Link to group home page.
+1. Reminder to indicate related members, per Process Document.
+
+### Information in Call for Votes  {#cfv-info}
+
+1. End date and time (23:59 ET) of voting period, usually **4 weeks**.
+1. Send votes to board-vote@w3.org. There is an auto-responder set up for this list; adjust as necessary.
+1. List of nominees. Indicate that the order of names is authoritative, and used in RFC3797 calculations. (Aim for alphabetical order by last name with affiliation next to name). Thank nominees and AC reps who nominated them.
+1. Link to a public page with statements about nominees ([sample](https://www.w3.org/2014/12/01-tag-nominations)). (Update that page to link to the WBS form for voting.)
+1. Number of seats up for election (and who holds them currently). Also, list names of people whose terms are not ending.
+1. Each AC representative may vote for up to the number of available seats. State that:
+    
+    - The results of the vote are only visible to the Team, but that information will be archived.
+    - When RFC 3797 is used in case of a tie, the names of candidates who tied will be listed.
+1. Term start date and duration of terms (may be one or two years in order to stagger).
+1. Include relevant [data for RFC3797](#using-rfc3797).
+1. Date of next scheduled face-to-face meeting for that group.
+1. Link to group home page.
+1. Reminder of requirement that Members disclose related Member relationships; that has an impact on who can vote in these elections.

--- a/process/pag.md
+++ b/process/pag.md
@@ -1,0 +1,80 @@
+---
+title: Patent Advisory Group procedures
+toc: true
+---
+
+This document specifies the procedures undertaken by the W3C Team, with the cooperation of others, in the early stages following the surfacing of an exception within the context of the [W3C Patent Policy](https://www.w3.org/policies/patent-policy/). In brief, an "[exception](https://www.w3.org/policies/patent-policy/#sec-Exception)" is a patent that has been, or may be, disclosed, and that is believed to be [essential](https://www.w3.org/policies/patent-policy/#def-essential) to implementation of a W3C Recommendation or a document on the Recommendation track, but is not available under W3C Royalty-Free (RF) licensing requirements. The normal results of such an exception is the launch of a Patent Advisory Group (PAG).
+
+The purpose of documenting the procedures here is to ensure that the Team, the W3C Members, the Working Group (WG), the patent holder, and the public have a clear understanding of the events that may unfold in the wake of an exception, and the expected timeline for such events.
+
+## Status of this Document  {#status}
+
+This document was reviewed by the W3C [Patents and Standards Interest Group](https://www.w3.org/2004/pp/psig/) in 2007 and published in the [W3C Patent Policy FAQ](https://www.w3.org/2003/12/22-pp-faq.html) in January 2008. Over time, the W3C expects acquire a larger set of best practices regarding PAG operations.
+
+## Procedures for Launching a PAG  {#launch}
+
+**Note**: Some of the links to examples below are Member confidential. The REX PAG documents are given as examples of content, though the timeline on which they were issued was slower than is described below. See the [principles](#principles) behind these procedures.
+
+### Schedule  {#schedule}
+
+The following deadlines ("must") and recommended ("should") deadlines are presented relative to the earlier of (a) the time of an exclusion within a WG, and (b) the time that a Chair of a WG requests that a PAG be convened.
+
+- Within 30 days: The Team must initiate discussions with the WG Chair, Team Contact and Members of the WG, as well as the patent holder, to support development of a strategy and plan for subsequent steps. Objectives of these discussions may include:
+  
+  - Ascertain the desired schedule for completing the PAG investigation in light of the WG's plans.
+  - Seek clarifications regarding the intent and content of the patent(s) from the patent holder. See if they are willing to retract their exclusion and/or offer licensing terms consistent with the Patent Policy. (PAG will likely seek additional data from them later.)
+  - Explore resource needs and availability. Consider Team resources. Explore the level of effort Members are willing to put into the PAG. Consider the need for outside legal counsel and the willingness for Member to help finance the necessary resources through financial contributions to the [Web Legal Support Fund](https://www.w3.org/2003/12/LegalDefenseFund.html).
+- Within 60 days: The Team must report to the W3C Advisory Committee on the status and plan regarding launching a PAG.
+- Within 90 days: The Team should launch the PAG, unless the discussions above provide a strong reason for an earlier launch, a later launch, or the removal of the need to launch (e.g., the exclusion is withdrawn or W3C Patent Policy licensing terms are granted).
+
+### Steps  {#steps}
+
+The following steps must be completed prior to and at the launch of the PAG (links to existing examples are illustrative, and not necessarily ideal):
+
+1. Development of PAG Charter ([REX PAG, Dec 2006](https://www.w3.org/2006/12/w3c-rex-pag-charter)).
+   
+   - Domain Lead and Team Contact are responsible for drafting.
+   - Seek feedback from the WG, the [Patent and Standards Interest Group](https://www.w3.org/2004/pp/psig/), and others as needed.
+   - Secure W3M approval.
+1. Creation of Supporting Systems
+   
+   - Archived Mailing Lists (where the primary work of the PAG is conducted must be consistent with the associated WG).
+     
+     - Member ([REX PAG, Dec 2006](https://lists.w3.org/Archives/Member/member-rex-pag/)). Subscribe all current AC Reps. Change depending upon the results of the WBS survey of the Members in the WG (see below).
+     - Public ([REX PAG, Dec 2006](https://lists.w3.org/Archives/Public/public-rex-pag/)).
+   - PAG Home pages (where the primary work of the PAG is conducted must be consistent with the associated WG).
+     
+     - Member ([REX PAG, Dec 2006](https://www.w3.org/2006/rex-pag/)).
+     - Public.
+   - Add links to mailing lists and PAG pages from the Public ([REX PAG, Dec 2006](https://lists.w3.org/Archives/Team/w3t-archive/2006Dec/0467.html)) and Member home pages of the WG.
+1. Call for Participation
+   
+   - Create WBS form for participation ([REX PAG, Dec 2006](https://www.w3.org/2002/09/wbs/33280/REX-PAG/))
+     
+     - Make it clear the AC Reps of the Members in the WG are the default participants in the PAG.
+     - An AC Rep may designate an alternative are members of the PAG, plus another person if desired (e.g., legal counsel).
+   - Send Participation form to Members ([REX PAG, Dec 2006](https://lists.w3.org/Archives/Member/w3c-svg-wg/2006OctDec/0491.html))
+1. Launch of the PAG
+   
+   - Announcement to Members ([REX PAG, Dec 2006](https://lists.w3.org/Archives/Member/w3c-ac-members/2006OctDec/0093.html))
+   - Announcement to the Public: Home page news ([REX PAG, Dec 2006](https://www.w3.org/news/2006/patent-advisory-group-for-remote-xml-events-rex-launched/)). Ensure there are clear links to the PAG charter, disclosures/exclusions and the organization holding the patent.
+   - Arrange for first teleconference no sooner than 2(4?) weeks after announcement.
+1. Conclusion of the PAG: Refer to the [W3C Patent Policy](https://www.w3.org/policies/patent-policy/#sec-PAG-conclude).
+
+## PAG Operations  {#operations}
+
+How a PAG operates will depend largely upon its charter, the evolution of the facts and circumstances associated with the exception, and the Member initiatives. A subset of things to keep in mind during PAG operations:
+
+- Remind the disclosure/excluder of the [ways the discloser/excluder can support the PAG process](https://www.w3.org/2003/12/22-pp-faq#howtohelp)
+- Think early about a call for prior art, and other public and Member support.
+- A spec will not make it past Candidate Recommendation without a [satisfactory outcome](https://www.w3.org/policies/patent-policy/#sec-PAG-conclude) from a PAG.
+
+## Principles Behind These Procedures  {#principles}
+
+The principles behind the launch procedures are derived from the W3C Patent Policy, and in particular, [Section 7](https://www.w3.org/policies/patent-policy/#sec-Exception) on Exception Handling.
+
+- *When to start the PAG depends on the situation*; but earlier is generally better than later. The timing of the launch of a PAG is at the discretion of the Director, based on consultation with the Chair of the relevant Working Group. The start of the PAG could be as early as before a exceptional patent it disclosed, to as late as during the Last Call or Candidate Recommendation stages. The goal is to start the PAG at a time when it is believed that the patent licensing problems can be best resolved \[[Section 7.4.1](https://www.w3.org/policies/patent-policy/#sec-PAG-procedures-timing)].
+- *The Working Group should continue to operate*. W3C should act so as to allow the relevant Working Group to keep working while the exception is being handled \[[Section 7.1](https://www.w3.org/policies/patent-policy/#sec-PAG-formation)], and to handle the exception effectively such that the group's work can continue with a high-level of certainty that their products will be implementable on RF licensing terms \[[Section 2](https://www.w3.org/policies/patent-policy/#sec-Licensing)]. Delays in addressing the exception could effect the motivation for the WG to move forward. Conclusions of the PAG and any subsequent, related actions by the Director and the AC should be completed before the specification in question is proposed to move to Proposed Recommendation \[[FAQ 29](https://www.w3.org/2003/12/22-pp-faq.html#trpub-during-pag)].
+- *All Members represented in the WG are members of the PAG*. This is not something to which a Member signs up for or resigns from, though a Member may designate an alternate and/or additional people to participate \[[Section 7.3](https://www.w3.org/policies/patent-policy/#sec-PAG-composition)].
+- *The level of access control for the PAG's main work is the same as that of the underlying WG* \[[Section 7.4.2](https://www.w3.org/policies/patent-policy/#sec-PAG-procedures-charter)].
+- *W3C will keep the public informed*. As soon as the PAG is convened, the PAG charter will be made public, along with all of the patent disclosure and licensing statements applicable to the WG \[[Section 7.4.2](https://www.w3.org/policies/patent-policy/#sec-PAG-procedures-charter)].

--- a/standards-track/rec-tips.md
+++ b/standards-track/rec-tips.md
@@ -24,7 +24,7 @@ Even when a specification is well-deployed, expect feedback and requests for cha
 1. Charter the Working Groups with public deliverables;
 1. Organize a [W3C Workshop](https://www.w3.org/events/workshops/);
 1. Organize joint meetings with other W3C groups or groups outside of W3C. Or just invite people to attend a few meetings to start dialog;
-1. Secure early attention from horizontal review groups within W3C (WAI, QA, I18N, TAG, Device Independence);
+1. Secure early attention from horizontal review groups within W3C (WAI, I18N, TAG, Security, Privacy);
 1. Publish primers and other outreach materials;
 1. Develop test suites and other supporting materials in parallel with the Recommendation track document
 1. Organize press releases with the Communications Team;
@@ -37,4 +37,4 @@ Members should expect that if they want to get work done faster within the W3C P
 1. Sponsor a technical writer with expertise to capture Working Group consensus and write terse, usable documents.
 1. Dedicate resources internally to developing software or test materials in parallel with the specification's development. Early implementation experience will shorten Candidate Recommendation time substantially.
 
-**Note**: W3C Fellows always contribute a lot, but may raise concerns among other Members that one Member's interests are over represented in a particular area.
+**Note**: [W3C Fellows](https://www.w3.org/careers/fellows/) always contribute a lot, but may raise concerns among other Members that one Member's interests are over represented in a particular area.

--- a/standards-track/rec-tips.md
+++ b/standards-track/rec-tips.md
@@ -1,0 +1,40 @@
+---
+title: Tips for Getting to Recommendation Faster
+toc: true
+---
+
+## Background
+
+In discussing this issue, the [W3C Advisory Board](https://www.w3.org/2002/ab/) has maintained that, while Working Groups should be able to move documents as quickly as possible through the [Recommendation track](https://www.w3.org/policies/process/#rec-track), speed was less important than technical quality, interoperability, and consensus and buy-in from the W3C Membership and Web community. Rather than create a special "expedited Recommendation track" which might undermine some of the quality assurance ensured by the current process, this document suggests steps for smoothing a document's way through the existing Recommendation track.
+
+## 1. Build consensus early within W3C
+
+Build consensus early around the scope of work. Some mechanisms available to Members include:
+
+- [W3C Member Submission Process](https://www.w3.org/policies/process/#Submission): Once acknowledged, Members can engage with their Advisory Committee Representative colleagues and the Team about how to bring this work to a chartered W3C Group.
+- [Community or Business Group](https://www.w3.org/community/): Build consensus within W3C about requirements documents, use cases, and early drafts of technical specifications.
+- When a Charter is proposed to the Advisory Committee, garner support from fellow W3C Members on w3c-ac-forum. When there is substantial support for new work among the Members, the Team may create a special mailing list for discussion among Members and Team about Group charter development. Start discussions with proposals, calendars, statements of expected resource commitments, and other such signals.
+
+A newly formed Working Group that starts with an already-deployed specification may advance to Candidate Recommendation as quickly as they wish, provided there is agreement in the Working Group to do so. Plan for an early face-to-face meeting for this type of decision.
+
+## 2. Build consensus early in the Web Community
+
+Even when a specification is well-deployed, expect feedback and requests for changes based on broader review than the initial authors. It may take some time to build awareness in other W3C groups, related standards organizations, and in the Web community generally. Some mechanisms that will help secure wide review include:
+
+1. Charter the Working Groups with public deliverables;
+1. Organize a [W3C Workshop](https://www.w3.org/events/workshops/);
+1. Organize joint meetings with other W3C groups or groups outside of W3C. Or just invite people to attend a few meetings to start dialog;
+1. Secure early attention from horizontal review groups within W3C (WAI, QA, I18N, TAG, Device Independence);
+1. Publish primers and other outreach materials;
+1. Develop test suites and other supporting materials in parallel with the Recommendation track document
+1. Organize press releases with the Communications Team;
+1. Plan for conference presence.
+
+## 3. Dedicate resources to the work
+
+Members should expect that if they want to get work done faster within the W3C Process, they may need to expend extra resources to do so (e.g., on communications). Some suggested mechanisms:
+
+1. Sponsor a technical writer with expertise to capture Working Group consensus and write terse, usable documents.
+1. Dedicate resources internally to developing software or test materials in parallel with the specification's development. Early implementation experience will shorten Candidate Recommendation time substantially.
+
+**Note**: W3C Fellows always contribute a lot, but may raise concerns among other Members that one Member's interests are over represented in a particular area.

--- a/standards-track/republishing.md
+++ b/standards-track/republishing.md
@@ -1,0 +1,59 @@
+---
+title: In-place modification of W3C Technical Reports
+toc: true
+---
+
+_This is the W3C Communications Team's policy regarding the in-place modification of some W3C Technical reports. See also the [Persistence Policy for technical reports](https://www.w3.org/policies/uri-persistence/)._
+
+## Classes of documents that may be modified  {#classes}
+
+1. Only "end state" documents may be modified in place at any time: Recommendations and Working Group Notes. See [permitted classes of modifications for "end state" documents](#endstate-modification)
+2. Revised Working Drafts (not First Public Working Drafts) may be modified in place *on the day of publication*. See [Modifications for ordinary Working Drafts](#ordinary-wds)
+3. Other classes of documents are corrected through republication.
+4. If a document has been superseded, it should not be modified in place.
+
+## Permitted classes of modifications for "end state" documents  {#endstate-modification}
+
+The only modifications allowed in place are:
+
+1. Fixes to broken markup (e.g., invalid markup)
+1. Fixed to broken links (i.e., URIs)
+1. Fixes to broken style sheets
+1. Some visible status updates, such as indicating newer versions
+1. [An individual's name upon request to a W3C Ombudsperson](https://www.w3.org/2016/02/trans-rec-edit.html)
+
+Except for those changes required by this policy in section four, no in-place changes to the text of a document, besides some visible status updates, are permitted, however minor.
+
+## Availability of the original version for "end state" documents  {#availability}
+
+The Webmaster must ensure that the original version of the document (i.e., before the in-place modification) is available in CVS.
+
+**Note:** The public should have access to the original version through a public read-only CVS server. One approach is to rename the original files and link to them from the status section of the new doc. The old docs should have updated status to indicate that they have been superseded and why.
+
+## Indication of changes in the document for "end state" documents  {#indication}
+
+1. The title page publication date must not be changed
+1. There must be a "reprinting" date in addition to the title page publication date. Example:
+   
+   *W3C Recommendation 15 March 2003 (Format and link errors corrected 1 Jan 2004)*
+1. The status section should provide further information about the nature of the changes.
+1. The status section should explain that the Team has kept a copy of the original draft.
+
+Examples:
+
+- [https://www.w3.org/TR/2000/REC-DOM-Level-2-Views-20001113/](https://www.w3.org/TR/2000/REC-DOM-Level-2-Views-20001113/)
+- [https://www.w3.org/TR/2003/REC-xptr-framework-20030325/](https://www.w3.org/TR/2003/REC-xptr-framework-20030325/)
+- [https://www.w3.org/TR/2016/NOTE-url-1-20161206/](https://www.w3.org/TR/2016/NOTE-url-1-20161206/)
+
+## Requesting an in-place modification for "end state" documents  {#requesting}
+
+Editors (or others) send a request to the Webmaster, cc'ing the project management lead, webreq, and w3t-comm. The request must include:
+
+1. A detailed list of changes
+1. Revised document(s) (including revised status section)
+
+If these conditions are met, the Webmaster will replace the published documents with the modified ones.
+
+## Modifications for ordinary Working Drafts  {#ordinary-wds}
+
+A revised Working Draft may be modified in-place only if the modifications are done on the *same day* of the original publication (Boston time). There are no restrictions on the set of permitted modifications and there is no need to indicate the changes in the document. Republication is achieved using the [W3C automatic publishing system](https://github.com/w3c/echidna/wiki).

--- a/transitions/details.md
+++ b/transitions/details.md
@@ -10,7 +10,7 @@ This document does not address:
 - Requirements for documents themselves; see [Technical Report Publication Policy](https://www.w3.org/pubrules/doc) ("pubrules") for this information.
 - What required information must be public; this is covered in [section 7.2](https://www.w3.org/policies/process/#requirements-and-definitions) of the Process Document and in the governing patent policy.
 - Possible next steps after each transition; see the description of the [Recommendation Track Process](https://www.w3.org/policies/process/#Reports).
-- The Comm Team's policy regarding [in-place modification of W3C Technical Reports](https://www.w3.org/2003/01/republishing/).
+- The Comm Team's policy regarding [in-place modification of W3C Technical Reports](../standards-track/republishing.md).
 
 Exceptions to these processes MAY be authorized by [@w3c/transitions](https://github.com/orgs/w3c/teams/transitions).
 

--- a/transitions/index.html
+++ b/transitions/index.html
@@ -122,7 +122,7 @@ toc: false
 
 		<p>You <em class="rfc2119">may</em> also follow <a href="?profile=CR&amp;cr=rec-update">Candidate Recommendation</a> for substantive corrections</p>
 
-		<p>We allow some <strong>in place modifications</strong> of Recommendations, including markup changes. See <a href="https://www.w3.org/2003/01/republishing/">In-place modification of W3C Technical Reports</a>.</p>
+		<p>We allow some <strong>in place modifications</strong> of Recommendations, including markup changes. See <a href="https://www.w3.org/guide/standards-track/republishing">In-place modification of W3C Technical Reports</a>.</p>
 	</div>
 
 	<div class="field">

--- a/transitions/index.html
+++ b/transitions/index.html
@@ -232,7 +232,7 @@ interactions with the W3C Communications Team.</p>
 			<strong>Note:</strong> If your specification involves (or updates) an Internet
 			Media Type, before the transition to
 			<span data-profile="FPWD">First Public</span>
-			<span class="status-name">STATUS</span>, see also <cite><a href="https://www.w3.org/2020/01/registering-mediatypes.html">How to Register
+			<span class="status-name">STATUS</span>, see also <cite><a href=""https://www.w3.org/guide/editor/mediatypes">Register
 					an Internet Media Type for a W3C Specification</a></cite>
 			<span class="mediatypespecifics" data-profile="FPWD">to review the entire Internet Media Type
 				registration process.</span>

--- a/transitions/nextstep.html
+++ b/transitions/nextstep.html
@@ -135,7 +135,7 @@ function findShortname(s) {
 }
 
 let BASE = "https://www.w3.org/guide/transitions/";
-let INPLACE = "<li><a href='https://www.w3.org/2003/01/republishing/'>In-place modification of W3C Technical Reports</a></li>";
+let INPLACE = "<li><a href='https://www.w3.org/guide/standards-track/republishing/'>In-place modification of W3C Technical Reports</a></li>";
 function listItem(text, query) {
 	return "<li><a href='" + BASE + '?' + query + "'>" + text + "</a></li>";
 }

--- a/transitions/wide-review-request.html
+++ b/transitions/wide-review-request.html
@@ -177,7 +177,7 @@ Subject: <span id='spec_shortname'></span> <span id='spec_date'></span>
     }
 
     let BASE = "https://www.w3.org/guide/transitions?";
-    let INPLACE = "<li><a href='https://www.w3.org/2003/01/republishing/'>In-place modification of W3C Technical Reports</a></li>";
+    let INPLACE = "<li><a href='https://www.w3.org/guide/standards-track/republishing/'>In-place modification of W3C Technical Reports</a></li>";
     function listItem(text, query) {
         let id = "option" + Math.round(Math.random() * 10000);
 	return `<li>`


### PR DESCRIPTION
- "Tips for Getting to Recommendation Faster" - https://www.w3.org/2002/05/rec-tips 
  => `/guide/standards-track/rec-tips`

- "In-place modification of W3C Technical Reports" - https://www.w3.org/2003/01/republishing/ 
  => `/guide/standards-track/republishing`

- "How to organize an Advisory Board or Technical Architecture Group election" - https://www.w3.org/2002/10/election-howto 
  => `/guide/process/election`

- "How to Close a Group (Team notes)" - https://www.w3.org/2003/04/closing-group.html
  => `/guide/process/closing-wg-implementation`

- "Version Management in W3C Technical Reports" - https://www.w3.org/2005/05/tr-versions
  => `/guide/editor/versioning`

- "URIs for W3C Namespaces" - https://www.w3.org/2005/07/13-nsuri
  => `/guide/editor/namespaces`

- "Register an Internet Media Type for a W3C Spec" - https://www.w3.org/2020/01/registering-mediatypes.html
  => `/guide/editor/mediatypes`

- "W3C Procedures for Launching and Operating a Patent Advisory Group (PAG)" - https://www.w3.org/2007/04/patent-exception-management.html
  => `/guide/process/pag`

See full discussion at https://github.com/w3c/guide/issues/290