### PR TITLE
charter extension: indicate whether/where the group is developing a new charter

### DIFF
--- a/process/charter.md
+++ b/process/charter.md
@@ -312,7 +312,7 @@ Team contacts should look at [how to setup a new group](../tools/new-group.md) o
 
 ### 3.6. Announcement of extension  {#announce-extension}
 
-When requesting that the W3C Communications Team announce a charter exension, use the [charter extension template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2Ftemplates&template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcharter-extension.html&submit=Continue...).
+When requesting that the W3C Communications Team announce a charter exension, use the [charter extension template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2Ftemplates&template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcharter-extension.html&submit=Continue...). If the group is developing a new charter, link to the GitHub repo where a new charter is being developed and to the issues link to raise comments.
 
 The W3C Communications Team then:
 


### PR DESCRIPTION
Make the following note from the [template announcement](https://www.w3.org/Team/Templates/charter-extension.html) more visible in Guidebook: 
[[
If the group is developing a new charter, link to the GitHub repo where a new charter is being developed and to the issues link to raise comments.
]]