### PR TITLE
Modified charter howto for charter refinement

### DIFF
--- a/process/adv-notice.md
+++ b/process/adv-notice.md
@@ -18,7 +18,9 @@ Per [section 4.1 of the Process Document](https://www.w3.org/policies/process/dr
 
 * A short summary of the proposal.
 * The location of the charter draft, which must be public.
-* How to participate in the discussion of this charter draft and where to file issues.
+* How to participate in the discussion of this charter draft and where to file issues, including:
+   * a link to the Github issues of the associated charter repository for public feedback
+   * a communication channel for Member-only discussions (e.g., w3c-ac-forum)
 * The expected duration of the charter refinement phase, which must not be less than 28 days, and should not be more than 6 months.
 * Who the Chartering Facilitator is.
 

--- a/process/adv-notice.md
+++ b/process/adv-notice.md
@@ -7,7 +7,7 @@ The W3C Process defines a [charter refinement phase](https://www.w3.org/policies
 
 This document describes how the W3C Communications Team announces the
 start of charter refinement with a *charter review notice*. For
-information about when the Strategy Team may request that the W3C Communications
+information about when the Technical Strategy Team may request that the W3C Communications
 Team send this announcement and activities following this
 announcement, see [How to create a Working Group or Interest
 Group](charter.md).
@@ -24,7 +24,7 @@ Per [section 4.1 of the Process Document](https://www.w3.org/policies/process/dr
 * The expected duration of the charter refinement phase, which must not be less than 28 days, and should not be more than 6 months.
 * Who the Chartering Facilitator is.
 
-In addition, the Strategy Team *may* include its own perspectives about the charter in the review notice.
+In addition, the Technical Strategy Team *may* include its own perspectives about the charter in the review notice.
 
 Please use the [charter review notice template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2F&amp;template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcharter-review-notice.html&amp;submit=Continue...) to create an initial draft.
 

--- a/process/adv-notice.md
+++ b/process/adv-notice.md
@@ -3,7 +3,7 @@ title: Announcing the start of Charter Refinement
 toc: yes
 ---
 
-The W3C Process defines a [charter refinement phase](https://www.w3.org/policies/process/drafts/#charter-initiation) to help ensure that charter drafts are mission-aligned, reflect community input and consensus, and have been well-socialized and widely reviewed *before* Advisory Committee review.
+The W3C Process defines a [charter refinement phase](https://www.w3.org/policies/process/#charter-initiation) to help ensure that charter drafts are mission-aligned, reflect community input and consensus, and have been well-socialized and widely reviewed *before* Advisory Committee review.
 
 This document describes how the W3C Communications Team announces the
 start of charter refinement with a *charter review notice*. For
@@ -14,7 +14,7 @@ Group](charter.md).
 
 # Drafting the charter review notice
 
-Per [section 4.1 of the Process Document](https://www.w3.org/policies/process/drafts/#charter-initiation) the charter review notice must include the following:
+Per [section 4.1 of the Process Document](https://www.w3.org/policies/process/#charter-initiation) the charter review notice must include the following:
 
 * A short summary of the proposal.
 * The location of the charter draft, which must be public.
@@ -44,6 +44,6 @@ to:
 
 # After the notice has been sent
 
-[Section 4.2 of the Process Document](https://www.w3.org/policies/process/drafts/#charter-development) describes activities during the refinement phase, and in particular the role of the Charter Facilitator to seek consensus and how and when any Formal Objections are handled.
+[Section 4.2 of the Process Document](https://www.w3.org/policies/process/#charter-development) describes activities during the refinement phase, and in particular the role of the Charter Facilitator to seek consensus and how and when any Formal Objections are handled.
 
 **Note**: Advance notice is not an indication that work *will* necessarily progress to Advisory Committee review.

--- a/process/adv-notice.md
+++ b/process/adv-notice.md
@@ -7,7 +7,7 @@ The W3C Process defines a [charter refinement phase](https://www.w3.org/policies
 
 This document describes how the W3C Communications Team announces the
 start of charter refinement with a *charter review notice*. For
-information about when the Strategy Team may request that the Comm
+information about when the Strategy Team may request that the W3C Communications
 Team send this announcement and activities following this
 announcement, see [How to create a Working Group or Interest
 Group](charter.md).
@@ -22,19 +22,19 @@ Per [section 4.1 of the Process Document](https://www.w3.org/policies/process/dr
 * The expected duration of the charter refinement phase, which must not be less than 28 days, and should not be more than 6 months.
 * Who the Chartering Facilitator is.
 
-In addition, the Team *may* include its own perspectives about the charter in the review notice.
+In addition, the Strategy Team *may* include its own perspectives about the charter in the review notice.
 
 Please use the [advance notice template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2F&amp;template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcharter-review-notice.html&amp;submit=Continue...) to create an initial draft.
 
 # Sending the charter review notice
 
-The Communications Team sends the charter review notice to:
+The W3C Communications Team sends the charter review notice to:
 
 * w3c-ac-members@w3.org (then forwards it to chairs@w3.org).
 * The affected group (in the case of a rechartering).
 
 In addition, unless this notice requires Member-only confidentiality
-(which should be rare), the Communications Team also sends the notice
+(which should be rare), the W3C Communications Team also sends the notice
 to:
 
 * public-new-work@w3.org

--- a/process/adv-notice.md
+++ b/process/adv-notice.md
@@ -1,72 +1,47 @@
 ---
-title: How to send advance notice of work to the Advisory Committee
+title: Announcing the start of Charter Refinement
 toc: yes
 ---
 
-This document describes the [Strategy Team](https://www.w3.org/staff/strat/)'s [implementation](#policy) of the [Process Document requirements](https://www.w3.org/policies/process/#WGCharterDevelopment) related to advance notice to the Advisory Committee of charters in development. See the [background](#bg) for the advance notice policy and this document.
+The W3C Process defines a [charter refinement phase](https://www.w3.org/policies/process/drafts/#charter-initiation) to help ensure that draft charters are mission-aligned, reflect community input and consensus, and have been well-socialized and widely reviewed *before* formal review by the Advisory Committee. 
 
-## Sending advance notice to the Advisory Committee {#policy}
+This document describes how the W3C Communications Team announces the
+start of charter refinement with a *charter review notice*. For
+information about when the Strategy Team may request that the Comm
+Team send this announcement and activities following this
+announcement, see [How to create a Working Group or Interest
+Group](charter.md).
 
-Who/Where
-: The [Strategy Team](https://www.w3.org/staff/strat/) determines when
-to inform the AC of work-in-progress. These announcements are sent by
-the [W3C Communications Team](https://www.w3.org/staff/comm/) to w3c-ac-members@w3.org
-and then forwarded to chairs@w3.org.
+# Drafting the charter review notice
 
-  Unless an advance notice strongly requires Member-only confidentiality
-(which should be rare), we also inform the public
-via [public-new-work@w3.org](https://lists.w3.org/Archives/Public/public-new-work/)
-(see [example](https://lists.w3.org/Archives/Public/public-new-work/2022Mar/0012.html))
-and [new-work@ietf.org](https://www.ietf.org/mailman/listinfo/new-work). This
-is done by the W3C Communications Team.
+Per [section 4.1 of the Process Document](https://www.w3.org/policies/process/drafts/#charter-initiation) the charter review notice must include the following:
 
-When
-: Specialists, in conjunction with the Strategy Lead, make this
-decision based on early assessment of the factors available in the
-"[Evaluation](https://github.com/w3c/strategy/blob/master/3.Evaluation.md)" section of the Funnel,
-as well as considering when it is useful to encourage broader input to
-discussion. In the Process-required notice to the AC, the Strategy
-team will give an early status report on the work and likely timeline
-for further progress (from information captured in the Funnel).
+* A short summary of the proposal.
+* The location of the charter draft, which must be public.
+* How to participate in the discussion of this charter draft and where to file issues.
+* The expected duration of the charter refinement phase, which must not be less than 28 days, and should not be more than 6 months.
+* Who the Chartering Facilitator is.
 
-  Advance notice is not an indication that work *will* necessarily be
-sent for charter review, but an indication that the Team is seriously
-evaluating possible work, and seeks wider feedback.
+In addition, the Team *may* include its own perspectives about the charter in the review notice.
 
-How/What
-: There is a [template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2F&amp;template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fadv-charter.html&amp;submit=Continue...)
-for advance notice. Please look for recent examples in the
-[w3c-ac-members archive](https://lists.w3.org/Archives/Member/w3c-ac-members/).
+Please use the [advance notice template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2F&amp;template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcharter-review-notice.html&amp;submit=Continue...) to create an initial draft.
 
-  The advance notice announcement to the Membership MUST include this
-information:
+# Sending the charter review notice
 
-  - A summary of the intended work.
-  - A statement welcoming the Members to use w3c-ac-forum for general expressions of interest and support.
-  - A request that Members send substantive comments and engage on substantive discussion on a different mailing list or github repository (i.e., **other than w3c-ac-forum**).
-  - If applicable, a statement that the archive of this second list is Member-visible.
-  - Contact information if people have questions; generally these will be the names of one or more people on the Team.
+The Communications Team sends the charter review notice to:
 
-  The advance notice announcement to the Membership SHOULD include this
-information:
+* w3c-ac-members@w3.org (then forwards it to chairs@w3.org).
+* The affected group (in the case of a rechartering).
 
-  - Expectations about when a formal Advisory Commitee Review might begin.
+In addition, unless this notice requires Member-only confidentiality
+(which should be rare), the Communications Team also sends the notice
+to:
 
-  The advance notice announcement to the Membership MAY include this
-information:
+* public-new-work@w3.org
+* new-work@ietf.org
 
-  - Pointers to draft materials. In other words, the announcement is not
-required to include a draft charter, but if one is available, please include it.
-  - Information about other mailing lists for comments, as the situation requires.
+# After the notice has been sent
 
-## Background for this document {#bg}
+[Section 4.2 of the Process Document](https://www.w3.org/policies/process/drafts/#charter-development) describes activities during the refinement phase, and in particular the role of the Charter Facilitator to seek consensus and how and when any Formal Objections are handled.
 
-The [Process Document requirements](https://www.w3.org/policies/process/#WGCharterDevelopment) for advance notice were introduced in response to requests from Members to be more in the loop earlier for work in development. These requirements were added to provide additional transparency to some work carried out (in general) by the Team, to encourage Members to show support for work in development early (on w3c-ac-forum), and to enable those interested in shaping a charter to participate on a separate list (so as not to flood w3c-ac-forum).
-
-Hence the sentence in the Process Document:
-> Advisory Committee representatives MAY provide feedback on the Advisory Committee discussion list or via other designated channels.
-
-These ideas are further discussed in [Tips for Getting to Recommendation Faster](../standards-track/rec-tips.md),
-in particular:
-
-> When a Charter is proposed to the Advisory Committee, garner support from fellow W3C Members on w3c-ac-forum. When there is substantial support for new work among the Members, the Team may create a special mailing list for discussion among Members and Team about Group charter development. Start discussions with proposals, calendars, statements of expected resource commitments, and other such signals.
+**Note**: Advance notice is not an indication that work *will* necessarily progress to formal Advisory Committee review.

--- a/process/adv-notice.md
+++ b/process/adv-notice.md
@@ -3,7 +3,7 @@ title: Announcing the start of Charter Refinement
 toc: yes
 ---
 
-The W3C Process defines a [charter refinement phase](https://www.w3.org/policies/process/drafts/#charter-initiation) to help ensure that draft charters are mission-aligned, reflect community input and consensus, and have been well-socialized and widely reviewed *before* formal review by the Advisory Committee. 
+The W3C Process defines a [charter refinement phase](https://www.w3.org/policies/process/drafts/#charter-initiation) to help ensure that charter drafts are mission-aligned, reflect community input and consensus, and have been well-socialized and widely reviewed *before* Advisory Committee review.
 
 This document describes how the W3C Communications Team announces the
 start of charter refinement with a *charter review notice*. For
@@ -24,7 +24,7 @@ Per [section 4.1 of the Process Document](https://www.w3.org/policies/process/dr
 
 In addition, the Strategy Team *may* include its own perspectives about the charter in the review notice.
 
-Please use the [advance notice template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2F&amp;template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcharter-review-notice.html&amp;submit=Continue...) to create an initial draft.
+Please use the [charter review notice template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2F&amp;template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcharter-review-notice.html&amp;submit=Continue...) to create an initial draft.
 
 # Sending the charter review notice
 
@@ -44,4 +44,4 @@ to:
 
 [Section 4.2 of the Process Document](https://www.w3.org/policies/process/drafts/#charter-development) describes activities during the refinement phase, and in particular the role of the Charter Facilitator to seek consensus and how and when any Formal Objections are handled.
 
-**Note**: Advance notice is not an indication that work *will* necessarily progress to formal Advisory Committee review.
+**Note**: Advance notice is not an indication that work *will* necessarily progress to Advisory Committee review.

--- a/process/charter.md
+++ b/process/charter.md
@@ -1,5 +1,5 @@
 ---
-title: How to create a Working Group or Interest Group
+title: How to create a Working Group or Interest Group Charter
 toc: yes
 ---
 
@@ -23,20 +23,21 @@ In this document we describe the operational aspects of these phases.
 
 Within the chartering process, the following are [Team Decisions](https://www.w3.org/policies/process/#team-decision):
 
-* Appointment of Working and Interest Group Chairs.
-* Whether or not to initiate the charter refinement phase.
-* Whether or not to initiate Advisory Committee review (or, "AC Review").
+* Whether to [initiate the charter refinement phase](https://www.w3.org/policies/process/#charter-initiation), or decline to do so.
+* Appointment or replacement of [Charter Facilitators](https://www.w3.org/policies/process/#charter-development).
+* Whether to [initiate Advisory Committee review](https://www.w3.org/policies/process/#charter-development) (or, "AC Review"), abandon the proposal, or extend the charter refinement period.
+* Appointment of [Working and Interest Group Chairs](https://www.w3.org/policies/process/#ReqsAllGroups).
 
-### 2.1 Technical Strategy Team role {#strategy-team-role}
+### 2.1 Technical Strategy Team role {#tech-strategy-team-role}
 
-In practice, the Team delegates these Team Decisions to the Technical Strategy Team, which manages the charter development process, including allocation of staff resources.
+In practice, the Team delegates these Team Decisions to the [Technical Strategy Team](https://www.w3.org/staff/strat/), which manages the charter development process, including allocation of staff resources.
 
-The Technical Strategy Team tracks charters through the process via the [Strategy Team's Technical Strategy Pipeline](https://github.com/orgs/w3c/projects/97) (or "pipeline" in this document).
+The Technical Strategy Team tracks charters through the process via the [W3C Technical Strategy Pipeline](https://github.com/orgs/w3c/projects/97/views/2) (or "pipeline" in this document). A dashboard of [Charters in development](https://www.w3.org/2024/03/charters-in-dev.html) is also available.
 {:#pipeline}
 
 ### 2.2 Chartering Facilitator
 
-The Technical Strategy Team Lead chooses (and may replace) a *Chartering Facilitator* to shepherd a given charter through the process. The Chartering Facilitator is typically from the Staff but is not required to be from the Staff. In the case of rechartering it is common to name the group's [Team Contact](../teamcontact/role.md) as the Chartering Facilitator.
+The Technical Strategy Team Lead chooses (and may replace) a *Chartering Facilitator* to shepherd a given charter through the process. The Chartering Facilitator is typically from the Staff but is not required to be from the Staff. In the case of rechartering it is common to name the group's [Staff Contact](../teamcontact/role.md) as the Chartering Facilitator.
 
 **Note:** If the Technical Strategy Team Lead cannot identify a Chartering Facilitator, there may be delays in advancing the charter through the process.
 {:#chartering-facilitator}
@@ -78,6 +79,12 @@ Inform the Technical Strategy Team
 **Note**: Even prior to the initiation of charter refinement, it is common for the charter proponents and Technical Strategy Team to work together to help prepare charters for broader audiences.
 
 ### 3.2 Initiation of charter refinement {#charter-refinement}
+
+An [Advisory Committee representative](https://www.w3.org/policies/process/#charter-initiation) may formally request that the Technical Strategy Team initiate charter refinement. Such request must be sent to the Technical Strategy Team ([team-strat@w3.org](mailto:team-strat@w3.org)), copying ([member-charters-review@w3.org](mailto:member-charters-review@w3.org)).
+
+An existing Working or Interest Group should request their Staff Contact to work with the Technical Strategy Team to initiate charter refinement.
+
+Community Groups interested in transitioning to a Working Group are encouraged to review [Considerations when transferring a CG Specification for Standardization](https://github.com/w3c/cg-council/blob/main/transfer-considerations.md) and to contact the Community Group Leads  ([team-community-process@w3.org](mailto:team-community-process@w3.org)) and/or the [Exploration IG](https://github.com/w3c/exploration-ig/issues).
 
 After consideration of the [charter assessment criteria](#charter-assessment-criteria) and a determination that the charter is well-formed (per the template and per Process section "[content of a charter](https://www.w3.org/policies/process/#WGCharter)"), the Technical Strategy Team Lead decides whether to initiate charter refinement.
 
@@ -138,7 +145,7 @@ The request to TiLT must include additional information as follows:
 
 The Chartering Facilitator records in the [pipeline](#pipeline) issue that a TiLT decision has been requested. 
 
-TiLT informs the Chartering Facilitator of their decision in the [pipeline](#pipeline) issue. This may take up to 2 weeks (but is frequently faster); see [Timing of responses from TiLT](tilt/#timing) for details.
+TiLT informs the Chartering Facilitator of their decision. This may take up to 2 weeks (but is frequently faster); see [Timing of responses from TiLT](tilt/#timing) for details.
 
 ### 3.5 Announcement of the TiLT decision
 
@@ -179,7 +186,7 @@ If approved, the Chartering Facilitator then works with the W3C Communications T
 
 ## 4. Existing groups  {#existing-groups}
 
-In this section we describe the operational aspects of extending or modifying the charter of an existing group. In these processes, a group's [Team Contact](../teamcontact/role.md) typically plays the role of the Chartering Facilitator.
+In this section we describe the operational aspects of extending or modifying the charter of an existing group. In these processes, a group's [Staff Contact](../teamcontact/role.md) typically plays the role of the Chartering Facilitator.
 
 ### 4.1 Request for short-term extension  {#extension-request}
 
@@ -241,16 +248,16 @@ Parallelize where possible:
 
 ### 5.3 Organizing the Call for Review  {#cfr}
 
-**Note:** Team Contacts should ensure that their work group participants are aware there is a review in progress.
+**Note:** Staff Contacts should ensure that their work group participants are aware there is a review in progress.
 
-The Team Contact:
+The Staff Contact:
 
 - Reuses an existing Team-only mailing list (e.g., [w3t-archive@w3.org](https://lists.w3.org/Archives/Team/w3t-archive/)) for the Advisory Committee review (or [creates a new Team-only mailing list](https://www.w3.org/Systems/Mail/Request/).)
   
   - If new, the mailing list should be named team-xxx-review@w3.org (in accordance with the [list name policy](https://www.w3.org/Systems/Mail/Request/#doc-listname)).
   - The mailing list must be Team-only.
   - The mailing list must be archived.
-  - The mailing list must have at least one subscriber to monitor traffic: the Team Contact.
+  - The mailing list must have at least one subscriber to monitor traffic: the Staff Contact.
 - Sends a request to the W3C Communications Team ([w3t-comm@w3.org](mailto:w3t-comm@w3.org)) asking that a Call for Review be sent to the AC. The request should be sent **at least three business days before** the anticipated start date of the review. The request must include:
   
   1. A w3.org URI to the proposed charter (not a github.io URI). This charter is public, and must not be altered, during the AC review.
@@ -262,7 +269,7 @@ The Team Contact:
 
 The W3C Communications Team encourages the Chartering Facilitator to include as part of the request, a draft Call for Review, created by using this [template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2FTemplates&template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcfr.html&submit=Continue...) (even if the URI to the questionnaire may not yet exist).
 
-The W3C Communications Team (or the motivated Team Contact) builds a [Call for Review questionnaire](https://www.w3.org/2002/09/wbs/33280/apCFRFactory). The URI for the questionnaire is added to the Call for Review announcement to members. In case of renewal of an existing charter, it is also useful to include a diff (you may wish to use the [HTML diff tool](https://services.w3.org/htmldiff)) between current and proposed charters in the Call for Review questionnaire.
+The W3C Communications Team (or the motivated Staff Contact) builds a [Call for Review questionnaire](https://www.w3.org/2002/09/wbs/33280/apCFRFactory). The URI for the questionnaire is added to the Call for Review announcement to members. In case of renewal of an existing charter, it is also useful to include a diff (you may wish to use the [HTML diff tool](https://services.w3.org/htmldiff)) between current and proposed charters in the Call for Review questionnaire.
 
 Once the Head of W3C Communications (or delegate) has approved the Call for Review and the questionnaire, the W3C Communications Team:
 
@@ -280,13 +287,13 @@ Once the Head of W3C Communications (or delegate) has approved the Call for Revi
 
 If there are only very minor changes to a charter resulting from the review, the (future) decision includes the original charter URI and an explanation of the changes and their rationale.
 
-If substantive changes are proposed in response to charter review, the Team Contact must request a review of the proposed changes to the individuals and organizations who responded to the Call for Review, copying the [member-charters-review@w3.org](https://lists.w3.org/Archives/Member/member-charters-review/) member-archived mailing list. The request must contain:
+If substantive changes are proposed in response to charter review, the Staff Contact must request a review of the proposed changes to the individuals and organizations who responded to the Call for Review, copying the [member-charters-review@w3.org](https://lists.w3.org/Archives/Member/member-charters-review/) member-archived mailing list. The request must contain:
 
 1. an explanation of the changes and their rationale
 2. a deadline for response (minimum of one week) if reviewers have concerns or if the changes would alter their reviews
 3. the URI for the questionnaire open to the AC
 
-If the work continues or derives from an existing group or community effort, the Team Contact should also send the [HTML diff](https://services.w3.org/htmldiff) and a public rationale to that group or community.
+If the work continues or derives from an existing group or community effort, the Staff Contact should also send the [HTML diff](https://services.w3.org/htmldiff) and a public rationale to that group or community.
 
 These communications should note that W3C has not yet approved the charter.
 
@@ -295,7 +302,7 @@ your review*.
 
 If anyone expresses new concern in response to the re-review, the Technical Strategy Team may attempt to resolve the concern (with re-review), formally open a new AC review, or the [W3C Council](../council/council.md) may treat it as an objection and overrule it.
 
-If there are substantive changes, before any announcement, the Team Contact:
+If there are substantive changes, before any announcement, the Staff Contact:
 
 1. Mints a new URI for the version of the charter that includes the changes. In the "Charter history" section of the charter, please link to the original (reviewed) charter.
 2. Modifies the original charter in place with the following status sentence at the top:
@@ -332,7 +339,7 @@ The Chartering Facilitator ensures that the following are done and the following
      - If the group is an IG that is just a mailing list:
 
        Document on the group's home page that to join the group people simply subscribe to the list.
-3. All relevant mailing lists exist. If not, the Team Contact may [create the mailing list(s)](https://www.w3.org/Systems/Mail/Request/).
+3. All relevant mailing lists exist. If not, the Staff Contact may [create the mailing list(s)](https://www.w3.org/Systems/Mail/Request/).
 4. The main mailing list is associated with the group via the [Group Service Management](https://www.w3.org/2011/04/dbwg/group-services) interface.
 5. Make sure the charter is public (since 2007, charters are public during AC review) and any final edits (e.g., addition of link to page for joining the group) have been made. If the group already exists, the new charter and the old charter should have two different URLs.
 6. Customize the ["onboarding" message](https://github.com/w3c/onboarding) that will be sent to participants as they join the group.
@@ -352,7 +359,7 @@ The Chartering Facilitator sends a draft announcement (combining W3C Decision an
 - Any substantive changes from the charter that was reviewed. Note: In case of charter renewal, it is useful to include a [HTML diff](https://services.w3.org/htmldiff) between the approved and previous charters.
 - A link to the group's public home page.
 - A link to a page with information about the mechanism used to join the group (e.g., a URI to the "join" page for a group under the W3C Patent Policy).
-- Name and contact information for the Team Contact(s).
+- Name and contact information for the Staff Contact(s).
 - AC review results of the proposed charter.
 - If applicable, the rationale for approving the group despite objections, or despite the fact it did not receive reviews [from at least 5% of the Membership](#review_threshold).
 
@@ -393,11 +400,11 @@ After sending the W3C Decision and Call for Participation:
 - For groups managed under the W3C Patent Policy (formerly IPP), the W3C Communications Team uses the [Groups DB](https://www.w3.org/admin/dashboard) interface to record that a Call for Participation was sent (so that all links via the Groups DB, including the charter one on the join page, are actually live).
 - If the group was "staged", the W3C Communications Team unstages it.
 - The public [list of groups](https://www.w3.org/groups/) is automatically updated from the Groups DB, including a 1-paragraph description.
-- Team Contact marks the chair(s) as such in the Group's admin view (this automatically adds the chair(s) to the [Chairs' group](https://www.w3.org/admin/othergroups/31972/show) which subscribes them to the chairs@w3.org mailing list).
-- Function Lead or Team Contact(s) update the Team's [effort tables](https://www.w3.org/2005/09/manage/).
-- For existing groups, Team Contact(s) ensures that Invited Expert statuses are being [reviewed in coordination with the group chair(s)](https://www.w3.org/invited-experts/#review). Team Contacts with questions about how an Invited Expert joins a group should consult the [Team Policy for Invited Experts](https://www.w3.org/2004/02/invited_expert).
+- Staff Contact marks the chair(s) as such in the Group's admin view (this automatically adds the chair(s) to the [Chairs' group](https://www.w3.org/admin/othergroups/31972/show) which subscribes them to the chairs@w3.org mailing list).
+- Function Lead or Staff Contact(s) update the Team's [effort tables](https://www.w3.org/2005/09/manage/).
+- For existing groups, Staff Contact(s) ensures that Invited Expert statuses are being [reviewed in coordination with the group chair(s)](https://www.w3.org/invited-experts/#review). Staff Contacts with questions about how an Invited Expert joins a group should consult the [Team Policy for Invited Experts](https://www.w3.org/2004/02/invited_expert).
 
-Team contacts should look at [how to setup a new group](../tools/new-group.md) once the call for participation is out.
+Staff Contacts should look at [how to setup a new group](../tools/new-group.md) once the call for participation is out.
 
 **Note:** When we recharter a work group and the charter scope has changed, we enter the CFP into the Group DB, which triggers messages to the group participants that they must rejoin. If the new charter doesn't have new deliverables involving new patent commitment, do not register the new CFP.
 
@@ -412,15 +419,15 @@ The W3C Communications Team then:
 - It is a good practice to forward the extension announcement to the public list of the group, and to follow-up on public-new-work.
 - updates the [list of groups](https://www.w3.org/groups/) accordingly.
 
-The Communications Team modifies (or asks the Team Contact) the Charter in place as follows:
+The Communications Team modifies (or asks the Staff Contact) the Charter in place as follows:
 
 - The "End Date" in the table at the top.
-- Any update to the Chair(s) (e.g., a Chair resigns or their affiliation changed), Team Contact(s) (e.g., names, FTEs), etc.
+- Any update to the Chair(s) (e.g., a Chair resigns or their affiliation changed), Staff Contact(s) (e.g., names, FTEs), etc.
 - The changes including extension history are documented in the "About this charter" section at the bottom and lists each extension dates and the pairs of from/until dates. (Note: If the group is developing a new charter, link to the GitHub repo of where the new charter is being developed).
 - The text "Note: The group will document significant changes from this initial schedule on the group home page." is updated with a link to the group's updated milestones (e.g., on the group's site) to say something like "Note: See changes from this initial schedule on the group home page."
 - Fix broken links.
 
-When a group **Chair** is (re)appointed or resigns, shortly before/after the announcement to w3c-ac-members@w3.org \[then forwarded to chairs@w3.org] (sample emails \[[1](https://www.w3.org/Search/Mail/Member/search?keywords=&hdr-1-name=subject&hdr-1-query=appointed&index-grp=Member__FULL%20Public__FULL&index-type=t&type-index=w3c-ac-members)]\[[2](https://www.w3.org/Search/Mail/Member/search?keywords=&hdr-1-name=subject&hdr-1-query=steps%20down&index-grp=Member__FULL%20Public__FULL&index-type=t&type-index=w3c-ac-members)]), The W3C Communications Team (or the Team Contact) modifies the charter, including:
+When a group **Chair** is (re)appointed or resigns, shortly before/after the announcement to w3c-ac-members@w3.org \[then forwarded to chairs@w3.org] (sample emails \[[1](https://www.w3.org/Search/Mail/Member/search?keywords=&hdr-1-name=subject&hdr-1-query=appointed&index-grp=Member__FULL%20Public__FULL&index-type=t&type-index=w3c-ac-members)]\[[2](https://www.w3.org/Search/Mail/Member/search?keywords=&hdr-1-name=subject&hdr-1-query=steps%20down&index-grp=Member__FULL%20Public__FULL&index-type=t&type-index=w3c-ac-members)]), The W3C Communications Team (or the Staff Contact) modifies the charter, including:
 
 - Update the "Chair" in the table at the top.
 - Document changes in "About this charter" section at the bottom.

--- a/process/charter.md
+++ b/process/charter.md
@@ -13,7 +13,7 @@ W3C creates charters for Working and Interest Groups based on W3C community inte
 
 * **Preparation** 
 * **Charter refinement** to help ensure charters are mission-aligned, reflect community input and consensus, and have been well-socialized and widely reviewed.
-* **Formal review by the W3C Advisory Committee**, followed by a W3C Decision (including handling of any [Formal Objections](../council/council.md)).
+* **Review by the W3C Advisory Committee**, followed by a W3C Decision (including handling of any [Formal Objections](../council/council.md)).
 
 In this document we describe the operational aspects of these phases.
 
@@ -21,47 +21,46 @@ In this document we describe the operational aspects of these phases.
 
 ## 2. Team Decisions
 
-Within the chartering process, the following are Team Decisions:
+Within the chartering process, the following are [Team Decisions](https://www.w3.org/policies/process/#team-decision):
 
 * Appointment of Working and Interest Group Chairs.
 * Whether or not to initiate the charter refinement phase.
-* Whether or not to initiate formal Advisory Committee review.
+* Whether or not to initiate Advisory Committee review (or, "AC Review").
 
 ### 2.1 Strategy Team role {#strategy-team-role}
 
-In practice, the Team delegates these Team Decisions to the Strategy Team, which manages the charter development process, including
-allocation of staff resources.
+In practice, the Team delegates these Team Decisions to the Strategy Team, which manages the charter development process, including allocation of staff resources.
 
 The Strategy Team tracks charters through the process via the [Strategy Team's Technical Strategy Pipeline](https://github.com/orgs/w3c/projects/97) (or "pipeline" in this document).
 {:#pipeline}
 
 ### 2.2 Chartering Facilitator
 
-The Strategy Team Lead chooses a *Chartering Facilitator* to shepherd a given charter through the process. This person is chosen (and may be replaced) by the Strategy Team. The Chartering Facilitator is typically from the Team but is not required to be from the Team. In the case of rechartering it is common to name the group's [Team Contact](../teamcontact/role.md) as the Chartering Facilitator.
+The Strategy Team Lead chooses (and may replace) a *Chartering Facilitator* to shepherd a given charter through the process. The Chartering Facilitator is typically from the Staff but is not required to be from the Staff. In the case of rechartering it is common to name the group's [Team Contact](../teamcontact/role.md) as the Chartering Facilitator.
 
 **Note:** If the Strategy Team Lead cannot identify a Chartering Facilitator, there may be delays in advancing the charter through the process.
 {:#chartering-facilitator}
 
 ### 2.3 Charter assessment criteria
 
-The Strategy Team considers the following when deciding whether to initiate charter refinement or AC review of a charter. The more these criteria are not met, the more likely it is the Team will not initiate charter refinement or AC review. In any decision not to initiate refinement or AC review, the Team grounds its rationale in these criteria.
+The Strategy Team considers the following when deciding whether to initiate charter refinement or AC review of a charter. The more these criteria are not met, the more likely it is the Strategy Team will not initiate charter refinement or AC review. In any decision not to initiate refinement or AC review, the Strategy Team grounds its rationale in these criteria.
 
 * Does the charter align with the W3C mission and/or principles (and in particular [W3C Statements](https://www.w3.org/TR/?filter-tr-name=&status%5B%5D=stmt))?
-* Does the charter align with established Web architecture?
+* Does the charter align with established web architecture?
 * Is there sufficient support for the charter?
 * Is there significant consensus for the charter? One example of lack of consensus is when there are two competing charters and the community has not yet converged.
 * Are there clear signals within the W3C community that the W3C Membership will participate in the work, or that organizations will join to do the work?
-* Does the Team have adequate resources for the group in light of current W3C priorities?
+* Does the Staff have adequate resources for the group in light of current W3C priorities?
 
 Please note:
 
-* Some of these criteria will be easier to evaluate after charter refinement (e.g, once there has been horizontal review).
-* The Team may still decide not to initiate refinement or AC review even if the criteria are met, but must provide rationale for the decision.
-* The Team may still decide to initiate refinement or AC review even if the criteria are not met, otherwise W3C might not be able to make progress in some scenarios (e.g., when there are multiple competing charters). Similarly, the Team must provide rationale for the decision.
+* Some of these criteria will be easier to evaluate after charter refinement (e.g., once there has been horizontal review).
+* The Strategy Team may still decide not to initiate refinement or AC review even if the criteria are met, but must provide rationale for the decision.
+* The Strategy Team may still decide to initiate refinement or AC review even if the criteria are not met, otherwise W3C might not be able to make progress in some scenarios (e.g., when there are multiple competing charters). Similarly, the Strategy Team must provide rationale for the decision.
 
 ## 3. Chartering new groups  {#new-charters}
 
-Discussions for new work happen in a variety of venues, including Member discussions, Workshops, Working / Interest / Community Groups, and the Team.
+Discussions for new work happen in a variety of venues, including Member discussions, Workshops, Working / Interest / Community Groups, and within the W3C Staff.
 
 ### 3.1 Preparation {#charter-prep}
 
@@ -76,7 +75,7 @@ Draft a charter
 Inform the Strategy Team
 : When ready (e.g., after sufficient discussion among stakeholders has taken place), inform the Strategy Team by [creating a new charter issue](https://github.com/w3c/strategy/issues/new?assignees=&labels=Evaluation%3A%20untriaged&template=04-Chartering.md&title=) in their [pipeline](#pipeline).  The Strategy Team uses this issue to provide updates on the charter's progress through the process. Discussions of the charter's content should continue to take place in the charter's own repo.
 
-**Note**: Even prior to the initiation of charter refinement, it is common for the charter proponents and Team to work together to help prepare charters for broader audiences.
+**Note**: Even prior to the initiation of charter refinement, it is common for the charter proponents and Strategy Team to work together to help prepare charters for broader audiences.
 
 ### 3.2 Initiation of charter refinement {#charter-refinement}
 
@@ -90,7 +89,7 @@ Select a Chartering Facilitator
 : The Strategy Team Lead selects a [Chartering Facilitator](#chartering-facilitator) and records that appointment in the [pipeline](#pipeline).
 
 Request announcement of initiation of charter refinement
-: The [Chartering Facilitator](#chartering-facilitator) then sends a request to the W3C Communications Team to [announce the initiation of charter refinement](adv-notice.md); that document lists requirements for the announcement. In practice, if the announcement would precede the formal call for AC review by only a short delay, we skip the refinement phase.
+: The [Chartering Facilitator](#chartering-facilitator) then sends a request to the W3C Communications Team to [announce the initiation of charter refinement](adv-notice.md); that document lists requirements for the announcement. In practice, if the announcement would precede the call for AC review by only a short delay, we skip the refinement phase.
 
 Record start of refinement
 : Once refinement has been announced, the Strategy Team Lead records the initiation of charter refinement in the [pipeline](#pipeline) issue.
@@ -99,11 +98,11 @@ Any Formal Objection to a Team Decision to initiate charter refinement is not co
 
 #### 3.2.2 Strategy Team decision not to initiate charter refinement
 
-If no Advisory Committee representative formally requested that the Team initiate charter refinement, then no further action is required of the Team.
+If no Advisory Committee representative formally requested that the Strategy Team initiate charter refinement, then no further action is required of the Strategy Team.
 
-However, if an Advisory Committee representative formally requested that the Team initiate charter refinement, the Team may deny such a request if it thinks the proposal is insufficiently mature, does not align with W3C’s scope and mission, or otherwise does not meet the [charter assessment criteria](#charter-assessment-criteria). The Team must reply with its rationale in the same forum where it received the request (or simply back to the AC representative in the case where only the Team received the request). 
+However, if an Advisory Committee representative formally requested that the Strategy Team initiate charter refinement, the Strategy Team may deny such a request if it thinks the proposal is insufficiently mature, does not align with W3C’s scope and mission, or otherwise does not meet the [charter assessment criteria](#charter-assessment-criteria). The Strategy Team must reply with its rationale in the same forum where it received the request (or simply back to the AC representative in the case where only the Strategy Team received the request). 
 
-This rejection is a [Team Decision](https://www.w3.org/policies/process/#team-decision). If the requestor so wishes, this decision and can be appealed only by 5 or more Members, through their Advisory Committee representative, formally objecting to the decision within 8 weeks of the decision being announced. In this case the Team must start an [appeal vote](https://www.w3.org/policies/process/drafts/#appeal-vote) on whether to overturn the Team Decision. (No action is required to be taken when fewer than 5 Members object.)
+This rejection is a [Team Decision](https://www.w3.org/policies/process/#team-decision). If the requestor so wishes, this decision can be appealed only by 5 or more Members, through their Advisory Committee representative, formally objecting to the decision within 8 weeks of the decision being announced. In this case the Strategy Team must start an [appeal vote](https://www.w3.org/policies/process/drafts/#appeal-vote) on whether to overturn the Team Decision. (No action is required to be taken when fewer than 5 Members object.)
 
 > **Note**: We do not expect to include operational details for handling these Formal Objections until we have gained experience.
 
@@ -127,7 +126,7 @@ Before the end of the announced duration for the charter refinement phase, The S
 
 The Chartering Facilitator proposes an option in a [request to TiLT](tilt/#request). In all cases, the request to TiLT must include the following information:
 
-* The status of horizontal reviews (including the list of completed reviews and timeouts) .
+* The status of horizontal reviews (including the list of completed reviews and timeouts).
 * Issues formally addressed and their resolutions. Track these in a disposition of comments highlighting significant changes to the charter and any issues not resolved by consensus.
 
 The request to TiLT must include additional information as follows:
@@ -157,7 +156,7 @@ Any other objections are processed normally (see [Addressing Formal Objections](
 
 ### 3.6 Advisory Committee Review  {#ac-review}
 
-The Chartering Facilitator roles follows these steps:
+The Chartering Facilitator follows these steps:
 
 Prepare for AC Review
 : Work with the W3C Communications Team to organize Advisory Committee review of a charter (see [implementation details for the review](#cfr)).
@@ -167,14 +166,14 @@ Monitor AC Review
 *Timing:*
 
 - [Per the W3C Process](https://www.w3.org/policies/process/#CharterReview), the review period is at least 28 days.
-- Any Advisory Committee representative may request an extended review period of any new or substantively modified Working Group charter as part of their response to the Call for Review. In this case the existing charter may need to be extended (see [extension template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2Ftemplates&template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcharter-extension.html&submit=Continue...)). In case of extended review period, the Team must ensure that the Call for Participation for the work group occurs at least 60 days after the Call for Review of its charter.
+- Any Advisory Committee representative may request an extended review period of any new or substantively modified Working Group charter as part of their response to the Call for Review. In this case the existing charter may need to be extended (see [extension template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2Ftemplates&template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcharter-extension.html&submit=Continue...)). In case of extended review period, the Staff  must ensure that the Call for Participation for the work group occurs at least 60 days after the Call for Review of its charter.
 - The handling of Formal Objections to a charter adds more time.
 
 Manage changes resulting from review
-: As a result of review, make any requested very minor changes (in place) to the charter. If substantive changes are proposed, then initiate review of those proposed changes. In either case, the Team follows a process for [managing changes to charters after review](#manage-changes).
+: As a result of review, make any requested very minor changes (in place) to the charter. If substantive changes are proposed, then initiate review of those proposed changes. In either case, the Strategy Team follows a process for [managing changes to charters after review](#manage-changes).
 
 Request approval from TiLT
-: Once the review has ended and [Formal Objections are addressed](../council/council.md), the Chartering Facilitator [requests approval from TiLT](tilt/#request). Record in the [pipeline](#pipeline) issue that a TiLT decision has been requested. TiLT informs the Chartering Facilitator of their decision. Allow approximately 2 weeks, but see [timing of responses from TiLT](tilt/#timing) for details.
+: Once the review has ended and [Formal Objections are addressed](../council/council.md), the Chartering Facilitator [requests approval from TiLT](tilt/#request) and records in the [pipeline](#pipeline) issue that a TiLT decision has been requested. TiLT informs the Chartering Facilitator of their decision. Allow approximately 2 weeks, but see [timing of responses from TiLT](tilt/#timing) for details.
 
 If approved, the Chartering Facilitator then works with the W3C Communications Team to [announce the decision](#announce-decision).
 
@@ -186,7 +185,7 @@ In this section we describe the operational aspects of extending or modifying th
 
 The W3C Process describes the [charter extensions](https://www.w3.org/policies/process/#charter-extension) and when they may occur. No Advisory Committee review is required for short-term extensions.
 
-The Team expects a charter extension to be no more than 6 months. Otherwise the Group must [recharter](#recharter-request) or justification must be provided to explain the delay.
+The Strategy Team expects a charter extension to be no more than 6 months. Otherwise the Group must [recharter](#recharter-request) or justification must be provided to explain the delay.
 
 Short-term extensions cannot exceed a total of one year from the original charter end date.
 
@@ -216,20 +215,20 @@ Follow process for creating a charter
 
 ## 5. Implementation details  {#implementation-details}
 
-The following sections are mostly intended as instructions to the Team and are included here for transparency.
+The following sections are mostly intended as instructions to the Strategy Team and are included here for transparency.
 
 ### 5.1 Sufficient Member support for a charter  {#baseline-support}
 
-Generally, the Team will expect to receive reviews for Charter
+Generally, the Strategy Team will expect to receive reviews for Charter
  proposals from at least 5% of the [Membership](https://www.w3.org/membership/list/). If
  the 5% threshold is not met, the Charter may still be approved, but
  additional scrutiny is warranted, and resource allocation may be
- limited. Additionally, the Team will continue to consider the number
+ limited. Additionally, the Strategy Team will continue to consider the number
  of declarations of intent to participate or implement the output of
  the work group.
  {:#review_threshold}
 
-Given the diversity of work underway in the Consortium, including [groups that focus on horizontal reviews](horizontal-groups.md) (e.g., accessibility, security, and internationalization), as well as technologies that are initially focused on by some segment of the Web's stakeholders, there are times where exceptions to this practice may be considered. In those cases, the Team will document reasons why the exception is made.
+Given the diversity of work underway in the Consortium, including [groups that focus on horizontal reviews](horizontal-groups.md) (e.g., accessibility, security, and internationalization), as well as technologies that are initially focused on by some segment of the web's stakeholders, there are times where exceptions to this practice may be considered. In those cases, the Strategy Team will document reasons why the exception is made.
 
 ### 5.2 Tips to speed up the process  {#speed-tips}
 
@@ -294,7 +293,7 @@ These communications should note that W3C has not yet approved the charter.
 > ***Suggested wording:*** *Please let us know by \[date+1 week] if you have concerns or if this change would alter
 your review*.
 
-If anyone expresses new concern in response to the re-review, the Team may attempt to resolve the concern (with re-review), formally open a new AC review, or the [W3C Council](../council/council.md) may treat it as an objection and overrule it.
+If anyone expresses new concern in response to the re-review, the Strategy Team may attempt to resolve the concern (with re-review), formally open a new AC review, or the [W3C Council](../council/council.md) may treat it as an objection and overrule it.
 
 If there are substantive changes, before any announcement, the Team Contact:
 

--- a/process/charter.md
+++ b/process/charter.md
@@ -17,7 +17,7 @@ W3C creates charters for Working and Interest Groups based on W3C community inte
 
 In this document we describe the operational aspects of these phases.
 
-**Note**: Organizing discussions and reviews, building consensus, and handling of formal objections all require time. People working on charters should expect the entire process to take multiple months.
+**Note**: Organizing discussions and reviews, building consensus, and handling of Formal Objections all require time. People working on charters should expect the entire process to take multiple months.
 
 ## 2. Team Decisions
 
@@ -70,7 +70,7 @@ Verify transition readiness
 : For a Working Group charter, review: [W3C Recommendation Track Readiness Best Practices](../standards-track/), [Tips for Getting to Recommendation Faster](https://www.w3.org/2002/05/rec-tips), and [How to transition work from a Community Group to a Working Group](cg-transition.md).
 
 Draft a charter
-: Use the [charter template](https://w3c.github.io/charter-drafts/charter-template.html) to create a public draft charter, [ideally on GitHub](https://w3c.github.io/charter-drafts/). This is where substantive discussion of the charter should take place, including issues and pull requests.
+: Use the [charter template](https://w3c.github.io/charter-drafts/charter-template.html) to create a public charter draft, [ideally on GitHub](https://w3c.github.io/charter-drafts/). This is where substantive discussion of the charter should take place, including issues and pull requests.
 
 Inform the Strategy Team
 : When ready (e.g., after sufficient discussion among stakeholders has taken place), inform the Strategy Team by [creating a new charter issue](https://github.com/w3c/strategy/issues/new?assignees=&labels=Evaluation%3A%20untriaged&template=04-Chartering.md&title=) in their [pipeline](#pipeline).  The Strategy Team uses this issue to provide updates on the charter's progress through the process. Discussions of the charter's content should continue to take place in the charter's own repo.

--- a/process/charter.md
+++ b/process/charter.md
@@ -3,78 +3,161 @@ title: How to create a Working Group or Interest Group
 toc: yes
 ---
 
-The W3C Process describes the [lifecycle of chartered groups](https://www.w3.org/policies/process/#group-lifecyle). At a high level, W3C approves a new Working Group or Interest Group charter after a series of reviews intended to improve the quality of the charter and generate interest in the work. The reviews typically happen in this order:
-
-- Early socialization (e.g., by the Team or in a Community Group)
-- Review by the W3C Strategy Team
-- More socialization within the community
-- W3C "Horizontal" Group review
-- Advisory Committee review
-- In the case of [Formal Objections](../council/council.md), W3C Council review
-
-In this document we describe the operational aspects of these reviews.
-
-*Timing:* Please note that these reviews take time, and people working on charters should expect the entire process to take multiple months.
+The W3C Process describes the [lifecycle of chartered groups](https://www.w3.org/policies/process/#group-lifecyle).
 
 **Note:** [Group closures](closing-wg.md) are addressed in other documentation.
 
-## 1. New groups  {#new-charters}
+## 1. Overview of charter development
+
+W3C creates charters for Working and Interest Groups based on W3C community interest. W3C fosters awareness of charters, improves their quality, and gauges Membership support in phases:
+
+* **Preparation** 
+* **Charter refinement** to help ensure charters are mission-aligned, reflect community input and consensus, and have been well-socialized and widely reviewed.
+* **Formal review by the W3C Advisory Committee**, followed by a W3C Decision (including handling of any [Formal Objections](../council/council.md)).
+
+In this document we describe the operational aspects of these phases.
+
+**Note**: Organizing discussions and reviews, building consensus, and handling of formal objections all require time. People working on charters should expect the entire process to take multiple months.
+
+## 2. Team Decisions
+
+Within the chartering process, the following are Team Decisions:
+
+* Appointment of Working and Interest Group Chairs.
+* Whether or not to initiate the charter refinement phase.
+* Whether or not to initiate formal Advisory Committee review.
+
+### 2.1 Strategy Team role {#strategy-team-role}
+
+In practice, the Team delegates these Team Decisions to the Strategy Team, which manages the charter development process, including
+allocation of staff resources.
+
+The Strategy Team tracks charters through the process via the [Strategy Team's Technical Strategy Pipeline](https://github.com/orgs/w3c/projects/97) (or "pipeline" in this document).
+{:#pipeline}
+
+### 2.2 Chartering Facilitator
+
+The Strategy Team Lead chooses a *Chartering Facilitator* to shepherd a given charter through the process. This person is chosen (and may be replaced) by the Strategy Team. The Chartering Facilitator is typically from the Team but is not required to be from the Team. In the case of rechartering it is common to name the group's [Team Contact](../teamcontact/role.md) as the Chartering Facilitator.
+
+**Note:** If the Strategy Team Lead cannot identify a Chartering Facilitator, there may be delays in advancing the charter through the process.
+{:#chartering-facilitator}
+
+### 2.3 Charter assessment criteria
+
+The Strategy Team considers the following when deciding whether to initiate charter refinement or AC review of a charter. The more these criteria are not met, the more likely it is the Team will not initiate charter refinement or AC review. In any decision not to initiate refinement or AC review, the Team grounds its rationale in these criteria.
+
+* Does the charter align with the W3C mission and/or principles (and in particular [W3C Statements](https://www.w3.org/TR/?filter-tr-name=&status%5B%5D=stmt))?
+* Does the charter align with established Web architecture?
+* Is there sufficient support for the charter?
+* Is there significant consensus for the charter? One example of lack of consensus is when there are two competing charters and the community has not yet converged.
+* Are there clear signals within the W3C community that the W3C Membership will participate in the work, or that organizations will join to do the work?
+* Does the Team have adequate resources for the group in light of current W3C priorities?
+
+Please note:
+
+* Some of these criteria will be easier to evaluate after charter refinement (e.g, once there has been horizontal review).
+* The Team may still decide not to initiate refinement or AC review even if the criteria are met, but must provide rationale for the decision.
+* The Team may still decide to initiate refinement or AC review even if the criteria are not met, otherwise W3C might not be able to make progress in some scenarios (e.g., when there are multiple competing charters). Similarly, the Team must provide rationale for the decision.
+
+## 3. Chartering new groups  {#new-charters}
 
 Discussions for new work happen in a variety of venues, including Member discussions, Workshops, Working / Interest / Community Groups, and the Team.
 
-Within the Team, the *Strategy Team* manages the charter development process, including allocation of staff resources. The Strategy Team tracks charters through the process via the [Strategy Team's Incubation Pipeline (Funnel)](https://github.com/orgs/w3c/projects/97) tool.
-{:#pipeline}
+### 3.1 Preparation {#charter-prep}
 
-### 1.1. Charter preparation {#charter-prep}
+Any party preparing a charter for a new Working Group or Interest Group follows these steps:
 
-These are the recommended steps for any party preparing a charter for a new Working Group or Interest Group:
+Verify transition readiness
+: For a Working Group charter, review: [W3C Recommendation Track Readiness Best Practices](../standards-track/), [Tips for Getting to Recommendation Faster](https://www.w3.org/2002/05/rec-tips), and [How to transition work from a Community Group to a Working Group](cg-transition.md).
 
-Check readiness
-: For a Working Group charter, review: [W3C Recommendation Track Readiness Best Practices](../standards-track/), [Tips for Getting to Recommendation Faster](../standards-track/rec-tips.md), and [How to transition work from a Community Group to a Working Group](cg-transition.md).
+Draft a charter
+: Use the [charter template](https://w3c.github.io/charter-drafts/charter-template.html) to create a public draft charter, [ideally on GitHub](https://w3c.github.io/charter-drafts/). This is where substantive discussion of the charter should take place, including issues and pull requests.
 
-Draft charter
-: Use the [charter template](https://w3c.github.io/charter-drafts/charter-template.html) to create a draft charter, ideally on GitHub. This is where substantive discussion of the charter should take place, including issues and pull requests. **Note:** There are ongoing discussions about making it easier for people to find draft charters, e.g., by using a single GitHub repo for all draft charters.
+Inform the Strategy Team
+: When ready (e.g., after sufficient discussion among stakeholders has taken place), inform the Strategy Team by [creating a new charter issue](https://github.com/w3c/strategy/issues/new?assignees=&labels=Evaluation%3A%20untriaged&template=04-Chartering.md&title=) in their [pipeline](#pipeline).  The Strategy Team uses this issue to provide updates on the charter's progress through the process. Discussions of the charter's content should continue to take place in the charter's own repo.
 
-Inform Strategy Team
-: When ready (e.g., after sufficient discussion among stakeholders has taken place), inform the Strategy Team by [creating a new charter issue](https://github.com/w3c/strategy/issues/new?assignees=&labels=Evaluation%3A%20untriaged&template=04-Chartering.md&title=) in their [pipeline](#pipeline). The Strategy Team will use this issue to provide updates on the charter's progress through the process. Discussions of the charter's content should continue to take place in the charter's own repo.
+**Note**: Even prior to the initiation of charter refinement, it is common for the charter proponents and Team to work together to help prepare charters for broader audiences.
 
-### 1.2. Strategy Team role  {#strategy-team-role}
+### 3.2 Initiation of charter refinement {#charter-refinement}
 
-When a new charter issue has been raised, the Strategy Team Lead assigns a staff member to shepherd the charter through the remainder of the process, the charter shepherd is the “assignee” of the issue in the pipeline. The Strategy Team typically discusses proposed charters at its regular meeting or on its mailing list. **Note:** If the Strategy Team Lead cannot identify a staff member, there may be delays in advancing the charter through subsequent reviews.
-{:#charter-shepherd}
+After consideration of the [charter assessment criteria](#charter-assessment-criteria) and a determination that the charter is well-formed (per the template and per Process section "[content of a charter](https://www.w3.org/policies/process/#WGCharter)"), the Strategy Team Lead decides whether to initiate charter refinement.
 
-The [charter shepherd](#charter-shepherd) (on behalf of the Strategy Team) roles include:
+#### 3.2.1 Strategy Team decision to initiate charter refinement
 
-Evaluate readiness
-: Let the proponents know if the charter is not well-formed (per the template and per Process section "[content of a charter](https://www.w3.org/policies/process/#WGCharter)"); if it is perceived to be harmful to the Web; or if it is not a priority at the current time.
+If the Strategy Team decides to initiate charter refinment, it follows these steps:
 
-Request advance notice to AC
-: If and when satisfied with the charter, raise awareness by
-requesting that the W3C Communications Team send an [advance notice to the W3C Advisory Committee](https://www.w3.org/policies/process/#WGCharterDevelopment);
-for details see [how to send advance notice of work to the Advisory Committee](adv-notice.md). Record in the [pipeline](#pipeline) issue
-that advance notice has been sent.  
-*Timing:* The exact timing of the advance notice may vary from charter to charter. In practice, if the advance notice would precede the formal call for review by only a short delay, we skip the advance notice.
+Select a Chartering Facilitator
+: The Strategy Team Lead selects a [Chartering Facilitator](#chartering-facilitator) and records that appointment in the [pipeline](#pipeline).
 
-{:#horizontal-review}
+Request announcement of initiation of charter refinement
+: The [Chartering Facilitator](#chartering-facilitator) then sends a request to the W3C Communications Team to [announce the initiation of charter refinement](adv-notice.md); that document lists requirements for the announcement. In practice, if the announcement would precede the formal call for AC review by only a short delay, we skip the refinement phase.
+
+Record start of refinement
+: Once refinement has been announced, the Strategy Team Lead records the initiation of charter refinement in the [pipeline](#pipeline) issue.
+
+Any Formal Objection to a Team Decision to initiate charter refinement is not considered registered until the close of any Advisory Committee Review of that charter, and is registered against that W3C Decision.
+
+#### 3.2.2 Strategy Team decision not to initiate charter refinement
+
+If no Advisory Committee representative formally requested that the Team initiate charter refinement, then no further action is required of the Team.
+
+However, if an Advisory Committee representative formally requested that the Team initiate charter refinement, the Team may deny such a request if it thinks the proposal is insufficiently mature, does not align with W3C’s scope and mission, or otherwise does not meet the [charter assessment criteria](#charter-assessment-criteria). The Team must reply with its rationale in the same forum where it received the request (or simply back to the AC representative in the case where only the Team received the request). 
+
+This rejection is a [Team Decision](https://www.w3.org/policies/process/#team-decision). If the requestor so wishes, this decision and can be appealed only by 5 or more Members, through their Advisory Committee representative, formally objecting to the decision within 8 weeks of the decision being announced. In this case the Team must start an [appeal vote](https://www.w3.org/policies/process/drafts/#appeal-vote) on whether to overturn the Team Decision. (No action is required to be taken when fewer than 5 Members object.)
+
+> **Note**: We do not expect to include operational details for handling these Formal Objections until we have gained experience.
+
+### 3.3 Activities during refinement
+
+The Chartering Facilitator ​is responsible for seeking community consensus among those participating in the refinement process and making decisions reflecting that consensus. The Chartering Facilitator follows these steps during refinement:
+
 Request horizontal review
-: Soon after, or in parallel, initiate [horizontal review](../documentreview/#how-to-get-horizontal-review). This is done by adding the "[Horizontal review requested](https://github.com/w3c/strategy/labels/Horizontal%20review%20requested)" label to the issue in the [pipeline](#pipeline).  
-*Timing:* Horizontal reviewers will usually respond within two weeks, though it is wise to allow for additional time. The charter shepherd may use the team-horizontal list to reach all the horizontal reviewers.  
-Horizontal reviews are not required for Groups that do not hold technical discussions, such as the Patents and Standards Interest Group.
+: Shortly after the initiation of refinement, request [horizontal review](../documentreview/#how-to-get-horizontal-review). This is done by adding the "[Horizontal review requested](https://github.com/w3c/strategy/labels/Horizontal%20review%20requested)" label to the issue in the [pipeline](#pipeline). Horizontal reviewers will usually respond within two weeks, though it is wise to allow for additional time. The Chartering Facilitator may use the team-horizontal list to reach all the horizontal reviewers. Horizontal reviews are not required for Groups that do not hold technical discussions, such as the Patents and Standards Interest Group.
 
-Prepare for TiLT Review
-:
-- *Charter changes*: Horizontal and other reviews may result in changes to the charter, or to objections. The charter shepherd should note in the [request to TiLT](tilt/#request) the horizontal review status (including completed reviews and any timeouts).
-- *Chairs:* Per the [W3C Process](https://www.w3.org/policies/process/#ReqsAllGroups) the W3C Team appoints Working and Interest Group Chairs. It is the responsibility of the charter shepherd to propose one or more Chairs in the request for TiLT approval.
+Ensure issues are formally addressed
+: All issues filed against the charter draft during refinement must be formally addressed by the Chartering Facilitator.
 
-Request approval from TiLT
-: When the charter shepherd is satisfied that as much progress as possible has been made, they [request approval from TiLT](tilt/#request). Record in the [pipeline](#pipeline) issue that a TiLT decision has been requested. TiLT informs the charter shepherd of their decision in the [pipeline](#pipeline) issue.  
-*Timing:* Allow approximately 2 weeks, but see [Timing of responses from TiLT](tilt/#timing) for details.
+### 3.4 Requesting a TiLT decision
 
-If approved, the charter shepherd works towards Advisory Committee Review.
+Before the end of the announced duration for the charter refinement phase, The Strategy Team (represented by the Technical Leadership Team, or TiLT and informed by the work of the Chartering Facilitator) must decide which of the following to do:
 
-### 1.3. Advisory Committee Review  {#ac-review}
+* Complete charter refinement by initiating AC Review of the charter draft.
+* Abandon the proposal.
+* Extend the charter refinement period.
 
-In this part of the process, the charter shepherd (on behalf of the Strategy Team) roles are:
+The Chartering Facilitator proposes an option in a [request to TiLT](tilt/#request). In all cases, the request to TiLT must include the following information:
+
+* The status of horizontal reviews (including the list of completed reviews and timeouts) .
+* Issues formally addressed and their resolutions. Track these in a disposition of comments highlighting significant changes to the charter and any issues not resolved by consensus.
+
+The request to TiLT must include additional information as follows:
+
+* To start AC review: proposed Chairs (per the [W3C Process](https://www.w3.org/policies/process/#ReqsAllGroups)).
+* To start AC review despite weak community consensus for the charter: rationale for pursuing this path.
+* To abandon refinement: rationale for abandoning the charter.
+* To extend refinement: rationale for the extension and a new end date. 
+
+The Chartering Facilitator records in the [pipeline](#pipeline) issue that a TiLT decision has been requested. 
+
+TiLT informs the Chartering Facilitator of their decision in the [pipeline](#pipeline) issue. This may take up to 2 weeks (but is frequently faster); see [Timing of responses from TiLT](tilt/#timing) for details.
+
+### 3.5 Announcement of the TiLT decision
+
+The Strategy Team must announce the TiLT decision with the same visibility as the notice of initiation of refinement, and must include a rationale if they are **not** initiating AC Review. In the case of initiating AC review, see the next section for steps.
+
+Objections to decisions pertaining to the content of the charter, as well as objections to initiating the AC Review, are considered registered at the close of the Advisory Committee Review of the charter, and are registered against that W3C Decision.
+
+Objections to abandoning the proposal or to extending the refinement period can be appealed only if 5 or more Members, through their Advisory Committee representative, formally object to the decision within 8 weeks of the decision. In this case, the Strategy Team must do one of the following:
+
+* Abide by the objectors' request, if they all agree on the alternative course of action (e.g., to abandon, extend, or complete charter refinement).
+* Initiate an [AC Review](https://www.w3.org/policies/process/drafts/#advisory-committee-review) to formally solicit the input of the community and take a W3C Decision on the subsequent course of action.
+* Convene a [Council](https://www.w3.org/policies/process/drafts/#w3c-council) to decide the subsequent course of action.
+
+Any other objections are processed normally (see [Addressing Formal Objections](https://www.w3.org/policies/process/drafts/#addressing-fo)).
+
+### 3.6 Advisory Committee Review  {#ac-review}
+
+The Chartering Facilitator roles follows these steps:
 
 Prepare for AC Review
 : Work with the W3C Communications Team to organize Advisory Committee review of a charter (see [implementation details for the review](#cfr)).
@@ -91,18 +174,15 @@ Manage changes resulting from review
 : As a result of review, make any requested very minor changes (in place) to the charter. If substantive changes are proposed, then initiate review of those proposed changes. In either case, the Team follows a process for [managing changes to charters after review](#manage-changes).
 
 Request approval from TiLT
-: Once the review has ended and [Formal Objections are addressed](../council/council.md), the charter shepherd [requests approval from TiLT](tilt/#request). Record in the [pipeline](#pipeline) issue that a TiLT decision has been requested. TiLT informs the charter shepherd of their decision.  
-*Timing:* Allow approximately 2 weeks, but see [Timing of responses from TiLT](tilt/#timing) for details.
+: Once the review has ended and [Formal Objections are addressed](../council/council.md), the Chartering Facilitator [requests approval from TiLT](tilt/#request). Record in the [pipeline](#pipeline) issue that a TiLT decision has been requested. TiLT informs the Chartering Facilitator of their decision. Allow approximately 2 weeks, but see [timing of responses from TiLT](tilt/#timing) for details.
 
-If approved, the charter shepherd then works with the W3C Communications Team to [announce the decision](#announce-decision).
+If approved, the Chartering Facilitator then works with the W3C Communications Team to [announce the decision](#announce-decision).
 
-## 2. Existing groups  {#existing-groups}
+## 4. Existing groups  {#existing-groups}
 
-Here we describe the operational aspects of extending or modifying the charter of an existing group.
+In this section we describe the operational aspects of extending or modifying the charter of an existing group. In these processes, a group's [Team Contact](../teamcontact/role.md) typically plays the role of the Chartering Facilitator.
 
-In these processes, a group's [Team Contact](../teamcontact/role.md) typically plays the role of the [charter shepherd](#charter-shepherd).
-
-### 2.1. Request for short-term extension  {#extension-request}
+### 4.1 Request for short-term extension  {#extension-request}
 
 The W3C Process describes the [charter extensions](https://www.w3.org/policies/process/#charter-extension) and when they may occur. No Advisory Committee review is required for short-term extensions.
 
@@ -110,11 +190,11 @@ The Team expects a charter extension to be no more than 6 months. Otherwise the 
 
 Short-term extensions cannot exceed a total of one year from the original charter end date.
 
-For a short-term extension, the charter shepherd roles are:
+For a short-term extension, the Chartering Facilitator roles are:
 
 Request approval from TiLT
-: The charter shepherd [requests approval of the short extension by TiLT](tilt/#request).  
-*Timing:* Allow approximately 2 weeks, but see [Timing of responses from TiLT](tilt/#timing) for details.
+: The Chartering Facilitator [requests approval of the short extension by TiLT](tilt/#request).  
+*Timing:* Allow approximately 2 weeks, but see [timing of responses from TiLT](tilt/#timing) for details.
 
 Request extension notice
 : If the decision is positive, request that the W3C Communications Team [announce an extension](#announce-extension).
@@ -122,11 +202,11 @@ Request extension notice
 Let the group know
 : The W3C Communications Team inform the group that its charter has been extended.
 
-### 2.2. Request for rechartering  {#recharter-request}
+### 4.2 Request for rechartering  {#recharter-request}
 
 A group recharters when it wishes to change its charter or needs long-term extension.
 
-In these processes, the roles of the charter shepherd are:
+In these processes, the roles of the Chartering Facilitator are:
 
 Record group decision
 : The group should discuss and record a formal decision to request extension or to recharter.
@@ -134,11 +214,11 @@ Record group decision
 Follow process for creating a charter
 : The handling of rechartering is almost the same as for [new charters](#new-charters). Note that, in addition to any content changes, the charter may need to be updated if the [charter template](https://w3c.github.io/charter-drafts/charter-template.html) has changed. Furthermore, the template tool will prompt for the inclusion of Patent Policy language and otherwise help you meet the [list of charter requirements in the Process](https://www.w3.org/policies/process/#WGCharter). For existing groups, the [charter assistant](https://www.w3.org/groups/wg/css/deliverables/) helps in producing the list of exclusion drafts.
 
-## 3. Implementation details  {#implementation-details}
+## 5. Implementation details  {#implementation-details}
 
 The following sections are mostly intended as instructions to the Team and are included here for transparency.
 
-### 3.1. Sufficient Member support for a charter  {#baseline-support}
+### 5.1 Sufficient Member support for a charter  {#baseline-support}
 
 Generally, the Team will expect to receive reviews for Charter
  proposals from at least 5% of the [Membership](https://www.w3.org/membership/list/). If
@@ -151,7 +231,7 @@ Generally, the Team will expect to receive reviews for Charter
 
 Given the diversity of work underway in the Consortium, including [groups that focus on horizontal reviews](horizontal-groups.md) (e.g., accessibility, security, and internationalization), as well as technologies that are initially focused on by some segment of the Web's stakeholders, there are times where exceptions to this practice may be considered. In those cases, the Team will document reasons why the exception is made.
 
-### 3.2. Tips to speed up the process  {#speed-tips}
+### 5.2 Tips to speed up the process  {#speed-tips}
 
 Parallelize where possible:
 
@@ -160,7 +240,7 @@ Parallelize where possible:
 - Start working on resolving Formal Objections to a charter as soon as those are received. Don't wait till the end of the AC review period.
 - Prepare a draft of the W3C Decision announcement before getting the approval from TiLT.
 
-### 3.3. Organizing the Call for Review  {#cfr}
+### 5.3 Organizing the Call for Review  {#cfr}
 
 **Note:** Team Contacts should ensure that their work group participants are aware there is a review in progress.
 
@@ -181,7 +261,7 @@ The Team Contact:
   5. A URI to the review of the proposed charter in the [Strategy GitHub repository](https://github.com/w3c/strategy/issues).
   6. The name of the Team-only mailing list for comments.
 
-The W3C Communications Team encourages the charter shepherd to include as part of the request, a draft Call for Review, created by using this [template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2FTemplates&template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcfr.html&submit=Continue...) (even if the URI to the questionnaire may not yet exist).
+The W3C Communications Team encourages the Chartering Facilitator to include as part of the request, a draft Call for Review, created by using this [template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2FTemplates&template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcfr.html&submit=Continue...) (even if the URI to the questionnaire may not yet exist).
 
 The W3C Communications Team (or the motivated Team Contact) builds a [Call for Review questionnaire](https://www.w3.org/2002/09/wbs/33280/apCFRFactory). The URI for the questionnaire is added to the Call for Review announcement to members. In case of renewal of an existing charter, it is also useful to include a diff (you may wish to use the [HTML diff tool](https://services.w3.org/htmldiff)) between current and proposed charters in the Call for Review questionnaire.
 
@@ -197,7 +277,7 @@ Once the Head of W3C Communications (or delegate) has approved the Call for Revi
    - That people who work for a Member organization should coordinate their comments through their Advisory Committee Representative.
 3. Send the same email to [new-work@ietf.org](https://www.ietf.org/mailman/listinfo/new-work). **Note:** public-new-work@w3.org used to cc new-work@ietf.org but due to mailing list configuration issues, we stopped that practice.
 
-### 3.4. Managing changes to charters after review  {#manage-changes}
+### 5.4 Managing changes to charters after review  {#manage-changes}
 
 If there are only very minor changes to a charter resulting from the review, the (future) decision includes the original charter URI and an explanation of the changes and their rationale.
 
@@ -226,11 +306,11 @@ If there are substantive changes, before any announcement, the Team Contact:
       
   ```
 
-### 3.5. Announcement of W3C Decision, Call for Participation  {#announce-decision}
+### 5.5 Announcement of W3C Decision, Call for Participation  {#announce-decision}
 
-#### 3.5.1. Preparation by the charter shepherd
+#### 5.5.1 Preparation by the Chartering Facilitator
 
-The charter shepherd ensures that the following are done and the following documentation is available **before** asking the W3C Communications Team to announce a group:
+The Chartering Facilitator ensures that the following are done and the following documentation is available **before** asking the W3C Communications Team to announce a group:
 
 1. TiLT has approved the group, whether or not preceded by an AC Review.
 2. The group exists in the [Groups DB](https://www.w3.org/admin/dashboard).
@@ -264,9 +344,9 @@ The W3C Communications Team should try to minimize the number of messages sent t
 
 *Timing:* this takes a week at most.
 
-#### 3.5.2. Organizing the W3C Decision, Call for Participation
+#### 5.5.2 Organizing the W3C Decision, Call for Participation
 
-The charter shepherd sends a draft announcement (combining W3C Decision and Call for Participation) to the W3C Communications Team ([w3t-comm@w3.org](mailto:w3t-comm@w3.org)) (using the [template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2FTemplates&template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcfp.html&submit=Continue...) as a starting point, or [sample announcement](https://www.w3.org/Search/Mail/Member/search?keywords=&hdr-1-name=subject&hdr-1-query=call%20for%20participation&index-grp=Member__FULL%20Public__FULL&index-type=t&type-index=w3c-ac-members)). The announcement must indicate:
+The Chartering Facilitator sends a draft announcement (combining W3C Decision and Call for Participation) to the W3C Communications Team ([w3t-comm@w3.org](mailto:w3t-comm@w3.org)) (using the [template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2FTemplates&template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcfp.html&submit=Continue...) as a starting point, or [sample announcement](https://www.w3.org/Search/Mail/Member/search?keywords=&hdr-1-name=subject&hdr-1-query=call%20for%20participation&index-grp=Member__FULL%20Public__FULL&index-type=t&type-index=w3c-ac-members)). The announcement must indicate:
 
 - Whether the group is approved and its charter end date.
 - The URI of the final charter.
@@ -299,7 +379,7 @@ The Head of W3C Communications (or delegate) must approve the W3C Decision and C
 
 **If the group is *rejected***, it is a good practice that the W3C Communications Team follows-up on the Advance Notice in public-new-work to close the loop for the public record.
 
-#### 3.5.3. After sending the W3C Decision, Call for Participation
+#### 5.5.3 After sending the W3C Decision, Call for Participation
 
 After sending the W3C Decision and Call for Participation:
 
@@ -322,7 +402,7 @@ Team contacts should look at [how to setup a new group](../tools/new-group.md) o
 
 **Note:** When we recharter a work group and the charter scope has changed, we enter the CFP into the Group DB, which triggers messages to the group participants that they must rejoin. If the new charter doesn't have new deliverables involving new patent commitment, do not register the new CFP.
 
-### 3.6. Announcement of extension  {#announce-extension}
+### 5.6 Announcement of extension  {#announce-extension}
 
 When requesting that the W3C Communications Team announce a charter extension, use the [charter extension template](https://www.w3.org/new-doc-from-template?location=%2FTeam%2Ftemplates&template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Fcharter-extension.html&submit=Continue...). If the group is developing a new charter, link to the GitHub repo where a new charter is being developed and to the issues link to raise comments.
 
@@ -346,8 +426,9 @@ When a group **Chair** is (re)appointed or resigns, shortly before/after the ann
 - Update the "Chair" in the table at the top.
 - Document changes in "About this charter" section at the bottom.
 
-## 4. Revision history  {#revision-history}
+## 6. Revision history  {#revision-history}
 
+- **2025-06**: Overhauled to integrate charter refinement introduced in the 2025 Process Document.
 - **2024-01**: Public comments and Formal Objections (including from Members) are now to be sent to public-review-comments@w3.org; various editorial changes.
 - **2023-10**: Updated following Process 2023 and reorganized to separate high-level processes from implementation.
 - **2012-08**: Added section 3.4 Horizontal Review following [discussion at May 2012 AC meeting on better integration of horizontal working groups](https://www.w3.org/2012/05/15-ac-minutes#item14) and discussion within the Team and Advisory Board.

--- a/process/charter.md
+++ b/process/charter.md
@@ -27,23 +27,23 @@ Within the chartering process, the following are [Team Decisions](https://www.w3
 * Whether or not to initiate the charter refinement phase.
 * Whether or not to initiate Advisory Committee review (or, "AC Review").
 
-### 2.1 Strategy Team role {#strategy-team-role}
+### 2.1 Technical Strategy Team role {#strategy-team-role}
 
-In practice, the Team delegates these Team Decisions to the Strategy Team, which manages the charter development process, including allocation of staff resources.
+In practice, the Team delegates these Team Decisions to the Technical Strategy Team, which manages the charter development process, including allocation of staff resources.
 
-The Strategy Team tracks charters through the process via the [Strategy Team's Technical Strategy Pipeline](https://github.com/orgs/w3c/projects/97) (or "pipeline" in this document).
+The Technical Strategy Team tracks charters through the process via the [Strategy Team's Technical Strategy Pipeline](https://github.com/orgs/w3c/projects/97) (or "pipeline" in this document).
 {:#pipeline}
 
 ### 2.2 Chartering Facilitator
 
-The Strategy Team Lead chooses (and may replace) a *Chartering Facilitator* to shepherd a given charter through the process. The Chartering Facilitator is typically from the Staff but is not required to be from the Staff. In the case of rechartering it is common to name the group's [Team Contact](../teamcontact/role.md) as the Chartering Facilitator.
+The Technical Strategy Team Lead chooses (and may replace) a *Chartering Facilitator* to shepherd a given charter through the process. The Chartering Facilitator is typically from the Staff but is not required to be from the Staff. In the case of rechartering it is common to name the group's [Team Contact](../teamcontact/role.md) as the Chartering Facilitator.
 
-**Note:** If the Strategy Team Lead cannot identify a Chartering Facilitator, there may be delays in advancing the charter through the process.
+**Note:** If the Technical Strategy Team Lead cannot identify a Chartering Facilitator, there may be delays in advancing the charter through the process.
 {:#chartering-facilitator}
 
 ### 2.3 Charter assessment criteria
 
-The Strategy Team considers the following when deciding whether to initiate charter refinement or AC review of a charter. The more these criteria are not met, the more likely it is the Strategy Team will not initiate charter refinement or AC review. In any decision not to initiate refinement or AC review, the Strategy Team grounds its rationale in these criteria.
+The Technical Strategy Team considers the following when deciding whether to initiate charter refinement or AC review of a charter. The more these criteria are not met, the more likely it is the Technical Strategy Team will not initiate charter refinement or AC review. In any decision not to initiate refinement or AC review, the Technical Strategy Team grounds its rationale in these criteria.
 
 * Does the charter align with the W3C mission and/or principles (and in particular [W3C Statements](https://www.w3.org/TR/?filter-tr-name=&status%5B%5D=stmt))?
 * Does the charter align with established web architecture?
@@ -55,8 +55,8 @@ The Strategy Team considers the following when deciding whether to initiate char
 Please note:
 
 * Some of these criteria will be easier to evaluate after charter refinement (e.g., once there has been horizontal review).
-* The Strategy Team may still decide not to initiate refinement or AC review even if the criteria are met, but must provide rationale for the decision.
-* The Strategy Team may still decide to initiate refinement or AC review even if the criteria are not met, otherwise W3C might not be able to make progress in some scenarios (e.g., when there are multiple competing charters). Similarly, the Strategy Team must provide rationale for the decision.
+* The Technical Strategy Team may still decide not to initiate refinement or AC review even if the criteria are met, but must provide rationale for the decision.
+* The Technical Strategy Team may still decide to initiate refinement or AC review even if the criteria are not met, otherwise W3C might not be able to make progress in some scenarios (e.g., when there are multiple competing charters). Similarly, the Technical Strategy Team must provide rationale for the decision.
 
 ## 3. Chartering new groups  {#new-charters}
 
@@ -72,37 +72,37 @@ Verify transition readiness
 Draft a charter
 : Use the [charter template](https://w3c.github.io/charter-drafts/charter-template.html) to create a public charter draft, [ideally on GitHub](https://w3c.github.io/charter-drafts/). This is where substantive discussion of the charter should take place, including issues and pull requests.
 
-Inform the Strategy Team
-: When ready (e.g., after sufficient discussion among stakeholders has taken place), inform the Strategy Team by [creating a new charter issue](https://github.com/w3c/strategy/issues/new?assignees=&labels=Evaluation%3A%20untriaged&template=04-Chartering.md&title=) in their [pipeline](#pipeline).  The Strategy Team uses this issue to provide updates on the charter's progress through the process. Discussions of the charter's content should continue to take place in the charter's own repo.
+Inform the Technical Strategy Team
+: When ready (e.g., after sufficient discussion among stakeholders has taken place), inform the Technical Strategy Team by [creating a new charter issue](https://github.com/w3c/strategy/issues/new?assignees=&labels=Evaluation%3A%20untriaged&template=04-Chartering.md&title=) in their [pipeline](#pipeline).  The Technical Strategy Team uses this issue to provide updates on the charter's progress through the process. Discussions of the charter's content should continue to take place in the charter's own repo.
 
-**Note**: Even prior to the initiation of charter refinement, it is common for the charter proponents and Strategy Team to work together to help prepare charters for broader audiences.
+**Note**: Even prior to the initiation of charter refinement, it is common for the charter proponents and Technical Strategy Team to work together to help prepare charters for broader audiences.
 
 ### 3.2 Initiation of charter refinement {#charter-refinement}
 
-After consideration of the [charter assessment criteria](#charter-assessment-criteria) and a determination that the charter is well-formed (per the template and per Process section "[content of a charter](https://www.w3.org/policies/process/#WGCharter)"), the Strategy Team Lead decides whether to initiate charter refinement.
+After consideration of the [charter assessment criteria](#charter-assessment-criteria) and a determination that the charter is well-formed (per the template and per Process section "[content of a charter](https://www.w3.org/policies/process/#WGCharter)"), the Technical Strategy Team Lead decides whether to initiate charter refinement.
 
-#### 3.2.1 Strategy Team decision to initiate charter refinement
+#### 3.2.1 Technical Strategy Team decision to initiate charter refinement
 
-If the Strategy Team decides to initiate charter refinment, it follows these steps:
+If the Technical Strategy Team decides to initiate charter refinment, it follows these steps:
 
 Select a Chartering Facilitator
-: The Strategy Team Lead selects a [Chartering Facilitator](#chartering-facilitator) and records that appointment in the [pipeline](#pipeline).
+: The Technical Strategy Team Lead selects a [Chartering Facilitator](#chartering-facilitator) and records that appointment in the [pipeline](#pipeline).
 
 Request announcement of initiation of charter refinement
 : The [Chartering Facilitator](#chartering-facilitator) then sends a request to the W3C Communications Team to [announce the initiation of charter refinement](adv-notice.md); that document lists requirements for the announcement. In practice, if the announcement would precede the call for AC review by only a short delay, we skip the refinement phase.
 
 Record start of refinement
-: Once refinement has been announced, the Strategy Team Lead records the initiation of charter refinement in the [pipeline](#pipeline) issue.
+: Once refinement has been announced, the Technical Strategy Team Lead records the initiation of charter refinement in the [pipeline](#pipeline) issue.
 
 Any Formal Objection to a Team Decision to initiate charter refinement is not considered registered until the close of any Advisory Committee Review of that charter, and is registered against that W3C Decision.
 
-#### 3.2.2 Strategy Team decision not to initiate charter refinement
+#### 3.2.2 Technical Strategy Team decision not to initiate charter refinement
 
-If no Advisory Committee representative formally requested that the Strategy Team initiate charter refinement, then no further action is required of the Strategy Team.
+If no Advisory Committee representative formally requested that the Technical Strategy Team initiate charter refinement, then no further action is required of the Technical Strategy Team.
 
-However, if an Advisory Committee representative formally requested that the Strategy Team initiate charter refinement, the Strategy Team may deny such a request if it thinks the proposal is insufficiently mature, does not align with W3C’s scope and mission, or otherwise does not meet the [charter assessment criteria](#charter-assessment-criteria). The Strategy Team must reply with its rationale in the same forum where it received the request (or simply back to the AC representative in the case where only the Strategy Team received the request). 
+However, if an Advisory Committee representative formally requested that the Technical Strategy Team initiate charter refinement, the Technical Strategy Team may deny such a request if it thinks the proposal is insufficiently mature, does not align with W3C’s scope and mission, or otherwise does not meet the [charter assessment criteria](#charter-assessment-criteria). The Technical Strategy Team must reply with its rationale in the same forum where it received the request (or simply back to the AC representative in the case where only the Technical Strategy Team received the request). 
 
-This rejection is a [Team Decision](https://www.w3.org/policies/process/#team-decision). If the requestor so wishes, this decision can be appealed only by 5 or more Members, through their Advisory Committee representative, formally objecting to the decision within 8 weeks of the decision being announced. In this case the Strategy Team must start an [appeal vote](https://www.w3.org/policies/process/#appeal-vote) on whether to overturn the Team Decision. (No action is required to be taken when fewer than 5 Members object.)
+This rejection is a [Team Decision](https://www.w3.org/policies/process/#team-decision). If the requestor so wishes, this decision can be appealed only by 5 or more Members, through their Advisory Committee representative, formally objecting to the decision within 8 weeks of the decision being announced. In this case the Technical Strategy Team must start an [appeal vote](https://www.w3.org/policies/process/#appeal-vote) on whether to overturn the Team Decision. (No action is required to be taken when fewer than 5 Members object.)
 
 > **Note**: We do not expect to include operational details for handling these Formal Objections until we have gained experience.
 
@@ -118,7 +118,7 @@ Ensure issues are formally addressed
 
 ### 3.4 Requesting a TiLT decision
 
-Before the end of the announced duration for the charter refinement phase, The Strategy Team (represented by the Technical Leadership Team, or TiLT and informed by the work of the Chartering Facilitator) must decide which of the following to do:
+Before the end of the announced duration for the charter refinement phase, The Technical Strategy Team (represented by the Technical Leadership Team, or TiLT and informed by the work of the Chartering Facilitator) must decide which of the following to do:
 
 * Complete charter refinement by initiating AC Review of the charter draft.
 * Abandon the proposal.
@@ -142,11 +142,11 @@ TiLT informs the Chartering Facilitator of their decision in the [pipeline](#pip
 
 ### 3.5 Announcement of the TiLT decision
 
-The Strategy Team must announce the TiLT decision with the same visibility as the notice of initiation of refinement, and must include a rationale if they are **not** initiating AC Review. In the case of initiating AC review, see the next section for steps.
+The Technical Strategy Team must announce the TiLT decision with the same visibility as the notice of initiation of refinement, and must include a rationale if they are **not** initiating AC Review. In the case of initiating AC review, see the next section for steps.
 
 Objections to decisions pertaining to the content of the charter, as well as objections to initiating the AC Review, are considered registered at the close of the Advisory Committee Review of the charter, and are registered against that W3C Decision.
 
-Objections to abandoning the proposal or to extending the refinement period can be appealed only if 5 or more Members, through their Advisory Committee representative, formally object to the decision within 8 weeks of the decision. In this case, the Strategy Team must do one of the following:
+Objections to abandoning the proposal or to extending the refinement period can be appealed only if 5 or more Members, through their Advisory Committee representative, formally object to the decision within 8 weeks of the decision. In this case, the Technical Strategy Team must do one of the following:
 
 * Abide by the objectors' request, if they all agree on the alternative course of action (e.g., to abandon, extend, or complete charter refinement).
 * Initiate an [AC Review](https://www.w3.org/policies/process/#advisory-committee-review) to formally solicit the input of the community and take a W3C Decision on the subsequent course of action.
@@ -170,7 +170,7 @@ Monitor AC Review
 - The handling of Formal Objections to a charter adds more time.
 
 Manage changes resulting from review
-: As a result of review, make any requested very minor changes (in place) to the charter. If substantive changes are proposed, then initiate review of those proposed changes. In either case, the Strategy Team follows a process for [managing changes to charters after review](#manage-changes).
+: As a result of review, make any requested very minor changes (in place) to the charter. If substantive changes are proposed, then initiate review of those proposed changes. In either case, the Technical Strategy Team follows a process for [managing changes to charters after review](#manage-changes).
 
 Request approval from TiLT
 : Once the review has ended and [Formal Objections are addressed](../council/council.md), the Chartering Facilitator [requests approval from TiLT](tilt/#request) and records in the [pipeline](#pipeline) issue that a TiLT decision has been requested. TiLT informs the Chartering Facilitator of their decision. Allow approximately 2 weeks, but see [timing of responses from TiLT](tilt/#timing) for details.
@@ -185,7 +185,7 @@ In this section we describe the operational aspects of extending or modifying th
 
 The W3C Process describes the [charter extensions](https://www.w3.org/policies/process/#charter-extension) and when they may occur. No Advisory Committee review is required for short-term extensions.
 
-The Strategy Team expects a charter extension to be no more than 6 months. Otherwise the Group must [recharter](#recharter-request) or justification must be provided to explain the delay.
+The Technical Strategy Team expects a charter extension to be no more than 6 months. Otherwise the Group must [recharter](#recharter-request) or justification must be provided to explain the delay.
 
 Short-term extensions cannot exceed a total of one year from the original charter end date.
 
@@ -215,20 +215,20 @@ Follow process for creating a charter
 
 ## 5. Implementation details  {#implementation-details}
 
-The following sections are mostly intended as instructions to the Strategy Team and are included here for transparency.
+The following sections are mostly intended as instructions to the Technical Strategy Team and are included here for transparency.
 
 ### 5.1 Sufficient Member support for a charter  {#baseline-support}
 
-Generally, the Strategy Team will expect to receive reviews for Charter
+Generally, the Technical Strategy Team will expect to receive reviews for Charter
  proposals from at least 5% of the [Membership](https://www.w3.org/membership/list/). If
  the 5% threshold is not met, the Charter may still be approved, but
  additional scrutiny is warranted, and resource allocation may be
- limited. Additionally, the Strategy Team will continue to consider the number
+ limited. Additionally, the Technical Strategy Team will continue to consider the number
  of declarations of intent to participate or implement the output of
  the work group.
  {:#review_threshold}
 
-Given the diversity of work underway in the Consortium, including [groups that focus on horizontal reviews](horizontal-groups.md) (e.g., accessibility, security, and internationalization), as well as technologies that are initially focused on by some segment of the web's stakeholders, there are times where exceptions to this practice may be considered. In those cases, the Strategy Team will document reasons why the exception is made.
+Given the diversity of work underway in the Consortium, including [groups that focus on horizontal reviews](horizontal-groups.md) (e.g., accessibility, security, and internationalization), as well as technologies that are initially focused on by some segment of the web's stakeholders, there are times where exceptions to this practice may be considered. In those cases, the Technical Strategy Team will document reasons why the exception is made.
 
 ### 5.2 Tips to speed up the process  {#speed-tips}
 
@@ -293,7 +293,7 @@ These communications should note that W3C has not yet approved the charter.
 > ***Suggested wording:*** *Please let us know by \[date+1 week] if you have concerns or if this change would alter
 your review*.
 
-If anyone expresses new concern in response to the re-review, the Strategy Team may attempt to resolve the concern (with re-review), formally open a new AC review, or the [W3C Council](../council/council.md) may treat it as an objection and overrule it.
+If anyone expresses new concern in response to the re-review, the Technical Strategy Team may attempt to resolve the concern (with re-review), formally open a new AC review, or the [W3C Council](../council/council.md) may treat it as an objection and overrule it.
 
 If there are substantive changes, before any announcement, the Team Contact:
 

--- a/process/charter.md
+++ b/process/charter.md
@@ -102,7 +102,7 @@ If no Advisory Committee representative formally requested that the Strategy Tea
 
 However, if an Advisory Committee representative formally requested that the Strategy Team initiate charter refinement, the Strategy Team may deny such a request if it thinks the proposal is insufficiently mature, does not align with W3C’s scope and mission, or otherwise does not meet the [charter assessment criteria](#charter-assessment-criteria). The Strategy Team must reply with its rationale in the same forum where it received the request (or simply back to the AC representative in the case where only the Strategy Team received the request). 
 
-This rejection is a [Team Decision](https://www.w3.org/policies/process/#team-decision). If the requestor so wishes, this decision can be appealed only by 5 or more Members, through their Advisory Committee representative, formally objecting to the decision within 8 weeks of the decision being announced. In this case the Strategy Team must start an [appeal vote](https://www.w3.org/policies/process/drafts/#appeal-vote) on whether to overturn the Team Decision. (No action is required to be taken when fewer than 5 Members object.)
+This rejection is a [Team Decision](https://www.w3.org/policies/process/#team-decision). If the requestor so wishes, this decision can be appealed only by 5 or more Members, through their Advisory Committee representative, formally objecting to the decision within 8 weeks of the decision being announced. In this case the Strategy Team must start an [appeal vote](https://www.w3.org/policies/process/#appeal-vote) on whether to overturn the Team Decision. (No action is required to be taken when fewer than 5 Members object.)
 
 > **Note**: We do not expect to include operational details for handling these Formal Objections until we have gained experience.
 
@@ -149,10 +149,10 @@ Objections to decisions pertaining to the content of the charter, as well as obj
 Objections to abandoning the proposal or to extending the refinement period can be appealed only if 5 or more Members, through their Advisory Committee representative, formally object to the decision within 8 weeks of the decision. In this case, the Strategy Team must do one of the following:
 
 * Abide by the objectors' request, if they all agree on the alternative course of action (e.g., to abandon, extend, or complete charter refinement).
-* Initiate an [AC Review](https://www.w3.org/policies/process/drafts/#advisory-committee-review) to formally solicit the input of the community and take a W3C Decision on the subsequent course of action.
-* Convene a [Council](https://www.w3.org/policies/process/drafts/#w3c-council) to decide the subsequent course of action.
+* Initiate an [AC Review](https://www.w3.org/policies/process/#advisory-committee-review) to formally solicit the input of the community and take a W3C Decision on the subsequent course of action.
+* Convene a [Council](https://www.w3.org/policies/process/#w3c-council) to decide the subsequent course of action.
 
-Any other objections are processed normally (see [Addressing Formal Objections](https://www.w3.org/policies/process/drafts/#addressing-fo)).
+Any other objections are processed normally (see [Addressing Formal Objections](https://www.w3.org/policies/process/#addressing-fo)).
 
 ### 3.6 Advisory Committee Review  {#ac-review}
 


### PR DESCRIPTION
In addition to modifying the flow to take into account charter refinement, modified the "advance notice" documentation to account for notification requirements in the Process 2025 draft and created a new (Team-visible) template for creating these announcements.

This pull request should not be merged until the process is updated.