### PR TITLE
[coc-incident-resolution-ombuds][editorial] Reorder text for better understandability

### DIFF
--- a/process/coc-incident-resolution-ombuds.md
+++ b/process/coc-incident-resolution-ombuds.md
@@ -8,21 +8,21 @@ As we engage with one another, incidents can happen. Incidents can take many for
 - Change behaviors that negatively affect other participants in W3C
 - Continue to safely work and contribute to the W3C after an issue has been raised
 
-The Code of Conduct is the standard that all W3C participants are required to follow and is used as the basis for any resolution and disciplinary actions. In exceptional circumstances, individuals may have their W3C participation suspended or withdrawn as a result of a complaint or investigation.
-
-All situations are different, and W3C participants are encouraged to use whichever method of incident resolution they feel comfortable with.
+The Code of Conduct is the standard that all W3C participants are required to follow and is used as the basis for any resolution and disciplinary actions.
 
 Participants are encouraged to try to resolve issues themselves if they feel safe doing so. Participants may contact a chair or team contact for help. However, if participants do not feel comfortable or safe resolving issues on their own or with the help of a team contact, they can get help through an ombud.
 
 Depending on the severity of the situation, it may not be appropriate to attempt to resolve the issue informally or in the context of the group. Participants should report an incident as soon as possible if they feel unsafe or threatened by the behavior or actions of other W3C participants.
 
+All situations are different, and W3C participants are encouraged to use whichever method of incident resolution they feel comfortable with.
+
+## Incident Resolution Procedures
+When an incident arises it is important for everyone involved to know what will happen and what resources are available to them. Any time a Code of Conduct violation or complaint occurs it is important that those involved, especially the party/parties affected by the incident, feel supported and respected.
+
 Everyone involved in the resolution process is expected to:
 - Show respect for others
 - Work together to resolve the complaint
 - Exercise good judgment, and make reasonable efforts to protect privacy and confidentiality of all participants
-
-## Incident Resolution Procedures
-When an incident arises it is important for everyone involved to know what will happen and what resources are available to them. Any time a Code of Conduct violation or complaint occurs it is important that those involved, especially the party/parties affected by the incident, feel supported and respected.
 
 How an incident is handled will depend on a number of factors including the type of incident, severity, frequency, and contributing factors. For example, has anyone been involved in incidents before? Is there a pattern?
 
@@ -34,6 +34,7 @@ The procedure for addressing an incident will include some or all of the followi
 * Resolution at the end of the process.
 
 For incidents that have a clear path to resolution and low severity (for example, a harsh criticism in a meeting or inappropriate language), the focus should be on coming to a shared understanding of what happened and agreeing to a path to resolution, such as an apology, agreed understanding for changes, or editing a comment or minutes.
+In exceptional circumstances, individuals may have their W3C participation suspended or withdrawn as a result of a complaint or investigation.
 
 ## Ombuds
 Ombuds are neutral third party advisors to participants who can provide guidance, advice, and support during the conflict resolution process. Where appropriate, ombuds can help mediate a process, but the role is mostly to help parties navigate next steps.


### PR DESCRIPTION
This commit reorders some sentences/paragraphs to improve the flow of topics and help people notice how things fit together. Specifically, it

* Moves the sentence about possible suspension from W3C from the introduction to the paragraph about resolutions, clarifying that this is a possible outcome in parallel and in contrast to apologies, editing minutes, etc.

* Moves the “All situations are different.. use whichever method” sentence to after the methods have been outlined, so that it's clearer what we're talking about.

* Shifts the list of “Everyone .. is expected to” bullet list from the intro into the incident resolution procedures, since it is a key part of how to enact those procedures, and helps clarify expectations for the content that follows.

No words were changed, added, or removed in this PR, only moved.