### PR TITLE
Used advisory terminology in guideline document

### DIFF
--- a/other/elected-body-communication-guidelines.md
+++ b/other/elected-body-communication-guidelines.md
@@ -38,7 +38,7 @@ When communicating a formal decision by the elected body you are a member of:
 
 - Express clearly what was decided and what was not decided.
 - Share the intended message with the rest of the elected body you are a member of, with time for them to review and comment on the message before it is released.
-- If time is limited because the elected body needs to respond urgently, a minimum review period of 24 hours plus review by the Chair(s) of the elected body is required.
+- If time is limited because the elected body needs to respond urgently, a minimum review period of 24 hours plus review by the Chair(s) of the elected body is advised.
 
 When discussing a decision made by the elected body you are a member of:
 


### PR DESCRIPTION
This document is a guideline. No matter how good its advice is, it is only advice. Except when conveying requirements established elsewhere authoritatively, guidelines should refrain from using phrasing like "is required", because guidelines cannot actually require anything.

In this PR, I suggest changing one such instance from "is required" to "is advised". No disagreement about the advice given, but as it isn't an actual formal requirement, it should not be presented as such.