### PR TITLE
Fix indentation of nested lists in Council steps

### DIFF
--- a/council/council-steps.md
+++ b/council/council-steps.md
@@ -9,35 +9,35 @@ This document describes the different steps to resolve a Formal Objection. It sh
 
 Note that at any step, the whole process might end by the originator by withdrawing the Formal Objection. This is the best outcome and should always be sought
 
-1.  Formal Objection received
-1.  The Staff Contact tries to resolve the Formal Objection before starting the process.
-1.  The FO stands: The Team assigns a "FO Assignee" to handle the Formal Objection. Note that is is not always the Staff Contact, but someone having knowledge of the issue raised in the FO.
-1.  The FO Assignee produces a Team Report:
-  *   The Team Report is circulated to the Team for review (one week review time)
-  *   The Team Report is circulated (at the same time or after Team review) to both parties.
-1.  The FO Assignee updates the [Formal Objection dashboard](https://www.w3.org/Member/wiki/FOdashboard).
-1.  The Council Staff Contact drafts an announcement and call for dismissal reasons with a minimum deadline of two weeks (See this [example](https://lists.w3.org/Archives/Member/w3c-ac-members/2024JanMar/0021.html), and the [Council composition](https://www.w3.org/policies/process/#council-composition)).
-  *   Announcement is sent to the AC members list
-1.  The Council Staff Contact creates a new [Group](https://www.w3.org/admin/othergroups/list) (name should be _Council-YYYY-MM-\<readable shortname>_) in the db, filled with all the potential members of this Potential Council
-1.  The Council Staff Contact creates a new [Mailing List](https://www.w3.org/Systems/Mail/Request/) (name should be _group-council-YYYY-MM-\<readable shortname>_)
-1.  The Council Staff Contact tries to find a Chair for the Potential Council
-1.  The Council Staff Contact circulates the collected dismissal reasons to the Potential Council (1 week to amend or answer)
-1.  The Council Staff Contact circulates the Team Report while point above is discussed, if available
-1.  The Council Staff Contact create a WBS for dismissal, with the option to self-recuse, and accept the Chair, if found; if not ask for chairs.
-1.  If the Team Report contains a Team Recommendation that can resolve the FO:
-  *   The Council Staff Contact create a WBS for an [Unanimous Short Ciruit](https://www.w3.org/policies/process/#council-short-circuit)
-  *   TAG and AB Staff Contact to ensure that _everyone_ is voting
-  *   If the USC succeed, the Council is not formed and the resolution is accepted
-1.  If the chair is not found, the Potential Council elects one chair
-1.  If the chair is found:
-  *   The Council Staff Contact announce with Comm the composition of the Council to the AC
-  *   The Council Staff Contact announce to the Council that the Council started
-  *   The Council Staff Contact update the FO Dashboard to indicate that the Council started and the date
-  *   The Council Staff Contact adds to the FO Dashboard the 45 days dealine for this Council
-1.  The Council chair\[s\] (and Council Staff Contact) may start an [Extraordinary Delegation](https://www.w3.org/policies/process/#council-delegation) WBS
-1.  The Council takes a decision
-1.  The Council writes a report
-1.  The Council Staff Contact ensures that the [W3C Council](https://www.w3.org/about/council/) as well as the FO Dashboard are updated
-1.  The decision is announced to the different parties and the AC
-1.  After the deadline for filing an appeal has passed, archive the Council Mailing List
+1. Formal Objection received
+1. The Staff Contact tries to resolve the Formal Objection before starting the process.
+1. The FO stands: The Team assigns a "FO Assignee" to handle the Formal Objection. Note that is is not always the Staff Contact, but someone having knowledge of the issue raised in the FO.
+1. The FO Assignee produces a Team Report:
+   * The Team Report is circulated to the Team for review (one week review time)
+   * The Team Report is circulated (at the same time or after Team review) to both parties.
+1. The FO Assignee updates the [Formal Objection dashboard](https://www.w3.org/Member/wiki/FOdashboard).
+1. The Council Staff Contact drafts an announcement and call for dismissal reasons with a minimum deadline of two weeks (See this [example](https://lists.w3.org/Archives/Member/w3c-ac-members/2024JanMar/0021.html), and the [Council composition](https://www.w3.org/policies/process/#council-composition)).
+   * Announcement is sent to the AC members list
+1. The Council Staff Contact creates a new [Group](https://www.w3.org/admin/othergroups/list) (name should be _Council-YYYY-MM-\<readable shortname>_) in the db, filled with all the potential members of this Potential Council
+1. The Council Staff Contact creates a new [Mailing List](https://www.w3.org/Systems/Mail/Request/) (name should be _group-council-YYYY-MM-\<readable shortname>_)
+1. The Council Staff Contact tries to find a Chair for the Potential Council
+1. The Council Staff Contact circulates the collected dismissal reasons to the Potential Council (1 week to amend or answer)
+1. The Council Staff Contact circulates the Team Report while point above is discussed, if available
+1. The Council Staff Contact create a WBS for dismissal, with the option to self-recuse, and accept the Chair, if found; if not ask for chairs.
+1. If the Team Report contains a Team Recommendation that can resolve the FO:
+   * The Council Staff Contact create a WBS for an [Unanimous Short Ciruit](https://www.w3.org/policies/process/#council-short-circuit)
+   * TAG and AB Staff Contact to ensure that _everyone_ is voting
+   * If the USC succeed, the Council is not formed and the resolution is accepted
+1. If the chair is not found, the Potential Council elects one chair
+1. If the chair is found:
+   * The Council Staff Contact announce with Comm the composition of the Council to the AC
+   * The Council Staff Contact announce to the Council that the Council started
+   * The Council Staff Contact update the FO Dashboard to indicate that the Council started and the date
+   * The Council Staff Contact adds to the FO Dashboard the 45 days dealine for this Council
+1. The Council chair\[s\] (and Council Staff Contact) may start an [Extraordinary Delegation](https://www.w3.org/policies/process/#council-delegation) WBS
+1. The Council takes a decision
+1. The Council writes a report
+1. The Council Staff Contact ensures that the [W3C Council](https://www.w3.org/about/council/) as well as the FO Dashboard are updated
+1. The decision is announced to the different parties and the AC
+1. After the deadline for filing an appeal has passed, archive the Council Mailing List
 


### PR DESCRIPTION
The detailed Council steps page had extraneous whitespaces after numbers and not enough spaces for nested unordered steps.

I quickly checked other Markdown files in the guide and couldn't spot other occurrences of the issue.

Note: Lists were still properly nested in the resulting HTML pages, likely because Jekyll parses the Markdown files with specific Markdown settings. But guide authors may render the Markdown content locally using their favorite Markdown editor, and most won't nest the lists.

Fixes #348.