### PR TITLE
Add index page for the `/other` endpoint

### DIFF
--- a/other/index.md
+++ b/other/index.md
@@ -1,0 +1,8 @@
+---
+title: Other guidelines
+toc: false
+---
+
+This section of the guidebook contains additional guidelines that do not fit into the main categories:
+
+- [Guidelines for communicating as a member of a W3C elected body](elected-body-communication-guidelines.md)


### PR DESCRIPTION
Via #288. Not much content in this page but it is now required for the breadcrumb navigation.