### PR TITLE
README: Add links to rendered pages, editorial updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 The repository for "[The Art of Consensus](https://www.w3.org/guide/)", W3C's Chair's Guidebook.
 
-Documentation on how to participate in W3C WGs is split between multiple wikipages, github repos and emails. This means new members find difficulty in finding information as to how to participate and maybe give up trying. This repository is the place to pull all of those
-together.
+Documentation on how to participate in W3C Working Groups is split between multiple wikipages, github repos and emails. This means new members find difficulty in finding information as to how to participate and maybe give up trying. This repository is the place to pull all of those together.
 
 ## Got a question?
 
@@ -17,38 +16,40 @@ The general edition of the Guidebook is managed by [@w3c/guidebook](https://gith
 
 The Guidebook uses the [W3C Jekyll theme](https://github.com/w3c/w3c-jekyll-theme). See the [README](https://github.com/w3c/w3c-jekyll-theme/blob/main/README.md) to run Jekyll locally.
 
-Note that latest versions of Ruby might created a [dependency issue]([url](https://github.com/jekyll/jekyll/pull/9392)). It is recommended to use the Ruby version mentioned in the [Github workflow]([url](https://github.com/w3c/guide/blob/1a2821f048c40648a9623ac8bd46056991e30b89/.github/workflows/jekyll-gh-pages.yml#L21)).
+Note that latest versions of Ruby might create a [dependency issue](https://github.com/jekyll/jekyll/pull/9392). It is recommended to use the Ruby version mentioned in the [Github workflow](https://github.com/w3c/guide/blob/main/.github/workflows/jekyll-gh-pages.yml#L21).
 
 ## In this repository
 
 * [/chair/](chair)
-  * Instructions on how to chair WGs and IGs including managing meetings, setting up the homepage, maintaining the calendar.
+  * [Resources for Group Chairs](https://www.w3.org/guide/chairs/).
+  * Instructions on how to chair Working Groups and Interest Groups including managing meetings, setting up the homepage, maintaining the calendar.
 * [/council/](council)
-  * Anything related to councils.
+  * [Anything related to W3C Councils](https://www.w3.org/guide/chairs/).
 * [/documentreview/](documentreview)
-  * How to do [wide review](https://www.w3.org/guide/documentreview/).
+  * [How to do wide review](https://www.w3.org/guide/documentreview/).
 * [/editor/](editor)
-  * [W3C Editors' Home Page](https://www.w3.org/guide/editor/).: How to author a specification, including ReSpec or other spec making programs.
+  * [W3C Editors' Home Page](https://www.w3.org/guide/editor/).
+  * How to author a specification, including ReSpec or other spec making programs.
 * [/github/](github)
-  * How to use Git and GitHub at W3C.
+  * How to use [Git and GitHub at W3C](https://www.w3.org/guide/github/).
 * [/manual-of-style/](manual-of-style)
   * The [W3C Manual of Style](https://www.w3.org/guide/manual-of-style/) for editors.
 * [/meetings/](meetings)
-  * Anything related to organizing meetings, including events.
+  * [Resources about W3C Meetings](https://www.w3.org/guide/manual-of-style/), including events.
 * [/process/](process)
-  * Anything related to additional guidelines when following the process.
+  * [Procedures related to the W3C Process](https://www.w3.org/guide/process/).
   * You may involve [@w3c/w3process-editors](https://github.com/orgs/w3c/teams/w3process-editors).
 * [/process/tilt/](process/tilt)
   * Anything related to [technical Team decision and verification](https://www.w3.org/guide/process/tilt/), except for transitions.
   * Managed by [@w3c/tilt](https://github.com/orgs/w3c/teams/tilt)
-* [/standards-track/](standards-track).
-  * Best Practices for Bringing Work to the W3C Recommendation Track.
+* [/standards-track/](standards-track)
+  * [Best Practices for Bringing Work to the W3C Recommendation Track](https://www.w3.org/guide/standards-track/).
 * [/teamcontact/](teamcontact)
-  * Guidance on the role of the team contact, and what to expect from them.
+  * [Guidance on the role of the team contact](https://www.w3.org/guide/teamcontact/), and what to expect from them.
 * [/transitions/](transitions)
   * [Organize a Technical Report Transition](https://www.w3.org/guide/transitions/).
   * Managed by [@w3c/transitions](https://github.com/orgs/w3c/teams/transitions).
 * [/other/](other)
-  * Related to [permanent groups](https://www.w3.org/groups/).
+  * [Additional guidelines](https://www.w3.org/guide/other/) that do not fit under main categories, notably guidelines related to [permanent groups](https://www.w3.org/groups/).
 
-Note: now that we have a repository for the guidebook, simply add your documentation to it, rather than creating new repositories.
+**Note:** now that we have a repository for the guidebook, simply add your documentation to it, rather than creating new repositories.


### PR DESCRIPTION
This adds links to the rendered HTML pages next to the mentions of the folders so that people can quickly check the contents of the underlying section in the guidebook. Fixes #314.

This also fixes a couple of typos and links.