### PR TITLE
Add links to PAS transposition process from index pages

### DIFF
--- a/index.md
+++ b/index.md
@@ -85,6 +85,7 @@ A list of [group procedures related to the W3C Process](process/#groups) is avai
 - Addressing formal objections: [best practices to resolve and decide Formal Objections](council/council.md) (aka council guide)
 - [Tips for getting to Recommendation faster](standards-track/rec-tips.md)
 - [Considerations on the final maturity stage of group deliverables](process/living-cr-rec.md)
+- Submitting a W3C Recommendation to ISO: the [PAS transposition process](process/pas-transposition-process.html)
 
 ### Test Suites {#testsuites}
 

--- a/process/index.md
+++ b/process/index.md
@@ -34,6 +34,7 @@ See also the [W3C Process for Busy People](https://github.com/w3c/wg-effectivene
   - [Obsoleting and Rescinding W3C Specifications](obsolete-rescinded-supserseded.md)
   - [Joint deliverables](joint-deliverables.md)
   - [How to license definitions and bindings](binding-license.md)
+  - Submitting a W3C Recommendation to ISO: the [PAS transposition process](pas-transposition-process.html)
 - [Non participant commitment](non-participant-commitment.md)
 - [Patent Advisory Group procedures](pag.md)
 - Participants


### PR DESCRIPTION
The page that describes the PAS transposition process was added recently but was only linked from one page focused on something else entirely. This adds links from the main index page and from the process-related index page.

Cc @daniel-montalvo.