### PR TITLE
Add guidance about when document titles may start with "W3C"

### DIFF
--- a/manual-of-style/index.html
+++ b/manual-of-style/index.html
@@ -427,6 +427,18 @@ information about the use of "version" and "edition". "Level" and
 convention.</p>
 
 <p>Capitalize title words following U.S. usage.</p>
+
+<p>Only use "W3C" to start the title of your document if it describes organizational aspects of W3C, not to confuse readers about the level of endorsement from W3C (<span class="not-en">e.g.</span>, when a document is not meant to become a Recommendation or is still under development).</p>
+<p class="note">There exist exceptions to the rule, either historical (<span class="not-en">e.g.</span>, [[[XMLSCHEMA11-1]]] [[XMLSCHEMA11-1]]) or to repurpose an acronym (<span class="not-en">e.g.</span>, [[[WCAG-3.0]]] [[WCAG-3.0]]).</p>
+<aside class="example" title="Documents that describe organizational aspects">
+  <p>Use of "W3C" in the following titles is appropriate:</p>
+  <ul>
+    <li>[[[W3C-PROCESS]]] [[W3C-PROCESS]]</li>
+    <li>[[[W3C-PATENT-POLICY]]] [[W3C-PATENT-POLICY]]</li>
+    <li>W3C Manual of Style (this document)</li>
+  </ul>
+</aside>
+
 </section>
 
 <section id="Editors">


### PR DESCRIPTION
This stems from the general recommendation not to make documents that are not endorsed by W3C look like they are. Use of "W3C" at the beginning of a document can be confusing, especially if the document is published on the Note track.

Conversely, it seems appropriate to use "W3C" at the beginning of documents that describe organizational aspects of W3C.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/guide/pull/414.html" title="Last updated on Mar 20, 2026, 4:29 PM UTC (dfffa24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/guide/414/38a7873...dfffa24.html" title="Last updated on Mar 20, 2026, 4:29 PM UTC (dfffa24)">Diff</a>