### PR TITLE
[Group creation] Drop note about possibly skipping the refinement

### DIFF
--- a/process/charter.md
+++ b/process/charter.md
@@ -98,7 +98,7 @@ Select a Chartering Facilitator
 : For the rechartering of existing groups, the Team Contact is selected by default as Chartering Facilitator and should assign the github issue to themselves. Otherwise, the [Technical Strategy Team Lead](https://www.w3.org/staff/strat/) or [Project &amp; Process Team Lead](https://www.w3.org/staff/project/) select a [Chartering Facilitator](#chartering-facilitator) and records that appointment in the [pipeline](#pipeline) by assigning github issues.
 
 Request announcement of initiation of charter refinement
-: The [Chartering Facilitator](#chartering-facilitator) then sends a request to the W3C Communications Team to [announce the initiation of charter refinement](adv-notice.md), copying the [Technical Strategy Team Lead](https://www.w3.org/staff/strat/) and the [Project &amp; Process Team Lead](https://www.w3.org/staff/project/); that document lists requirements for the announcement. In practice, if the announcement would precede the call for AC review by only a short delay, we skip the refinement phase.
+: The [Chartering Facilitator](#chartering-facilitator) then sends a request to the W3C Communications Team to [announce the initiation of charter refinement](adv-notice.md), copying the [Technical Strategy Team Lead](https://www.w3.org/staff/strat/) and the [Project &amp; Process Team Lead](https://www.w3.org/staff/project/); that document lists requirements for the announcement.
 
 Record start of refinement
 : Once refinement has been announced, the [Technical Strategy Team Lead](https://www.w3.org/staff/strat/) or [Project &amp; Process Team Lead](https://www.w3.org/staff/project/) records the initiation of charter refinement in the [pipeline](#pipeline) issue.


### PR DESCRIPTION
The note was a direct adaptation of a previous note that applied for the advance notice (adaptation was made in #323), but charter refinement cannot be skipped.