### PR TITLE
Turning doc into W3C Specification Editor Handbook

### DIFF
--- a/manual-of-style/index.html
+++ b/manual-of-style/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <head>
   <meta charset="utf-8">
-  <title>W3C Manual of Style</title>
+  <title>W3C Specification Editor Handbook</title>
   <script src='https://www.w3.org/Tools/respec/respec-w3c.js' defer class='remove'>
   </script>
   <script class='remove'>
@@ -133,15 +133,6 @@
           title: "Public archives of the <code>spec-prod@w3.org</code> mailing-list",
           href: "https://lists.w3.org/Archives/Public/"
         },
-        "STYLE-GUIDE": {
-          title: "Style Guide for Online Hypertext",
-          href: "https://www.w3.org/Provider/Style/",
-          authors: [
-            "T. Berners-Lee"
-          ],
-          publisher: "W3C",
-          date: "1992-1998"
-        },
         "TITLES": {
           title: "Please use titles, not addresses, as link text",
           href: "https://lists.w3.org/Archives/Public/www-html-editor/2000JanMar/0103",
@@ -177,9 +168,7 @@
 <body>
 
 <section id='abstract'>
-<p>This manual is a guide containing best current practice, written for editors and authors of W3C technical reports. No requirements
-for W3C publications are in this document. All requirements for W3C
-publications are in W3C [[[PUBRULES]]].</p>
+<p>This guide contains best current practice, written for editors and authors of W3C technical reports. It is a companion to the W3C Style Guide that documents W3C-specific conventions, including terminology, tone, voice, and editorial preferences. It complements the requirements for W3C publications that are in W3C [[[PUBRULES]]].</p>
 </section>
 
 <section id="sotd">
@@ -190,21 +179,9 @@ publications are in W3C [[[PUBRULES]]].</p>
 
 <p>Written for editors and authors of W3C technical reports, this
 document assumes that the reader is familiar with the
-[[[STYLE-GUIDE]]] [[STYLE-GUIDE]]. It is a companion to the
+W3C Style Guide [when ready, add link via 'localBiblio]. It is a companion to the
 mandatory [[[PUBRULES]]] [[PUBRULES]],
-called "pubrules" for short. Following the advice in this manual has
-benefits:</p>
-
-<ul>
-<li>Non-native English readers, native English readers, and translators
-will find your text easy to read and implement.</li>
-
-<li>All audiences can concentrate on ideas rather than the mechanics of
-reading.</li>
-
-<li>Polished at early public maturity levels, clean copy eliminates
-multiple "typo" reports.</li>
-</ul>
+called "pubrules" for short. 
 
 <p>Bear in mind that our reports are used as world-class primary
 reference material. Readability across a wide variety of browsers and
@@ -241,13 +218,11 @@ that documents are valid before requesting publication.</p>
 <section id="Accessibility">
 <h2>Accessibility</h2>
 
-<ul>
-<li>Follow the [[[WCAG]]] [[WCAG]]. See also [[[WCAG-Overview]]]
+<p></p>Follow the [[[WCAG]]] [[WCAG]]. See also [[[WCAG-Overview]]]
   [[WCAG-Overview]] for an introduction to the guidelines. Can
 simpler words express your ideas? Is your text marked up with
 structural elements? Are alternatives provided for auditory and visual
-content? See also <a href="https://www.w3.org/WAI/test-evaluate/">evaluation tools</a>.</li>
-</ul>
+content? See also <a href="https://www.w3.org/WAI/test-evaluate/">evaluation tools</a>.</p>
 </section>
 <section id="I18n">
 <h2>Internationalization</h2>
@@ -255,30 +230,6 @@ content? See also <a href="https://www.w3.org/WAI/test-evaluate/">evaluation too
 <p>Follow the guidelines in [[[INTERNATIONAL-SPECS]]] [[INTERNATIONAL-SPECS]] when producing your specification. You might also find it helpful to complete a <a href="https://www.w3.org/International/i18n-drafts/techniques/shortchecklist">self-review</a> early in the development process. If your specification touches on more complex issues, you can also reach out to the Internationalization Working Group for guidance.</p>
 
 <p>Internationalization terminology, particularly terms related to Unicode, can be rather precise. To help avoid problems with the need to define these, import the [[[Infra]]] [[Infra]] standard and [[[I18N-GLOSSARY]]] [[I18N-GLOSSARY]]. Use the terms found in these documents instead of creating your own and link your use of these terms to the definitions found in these documents. Instructions on how to do this can be found in an appendix of the [[[I18N-GLOSSARY]]].</p>
-
-<section id="general-i18n">
-	<h3>Write for a global audience</h3>
-	
-	<p>Keep in mind that W3C documents serve a global audience.</p>
-	
-	<ul>
-		<li>Avoid idioms that are U.S.- or English-specific in favor of more descriptive language.</li>
-		<li>Choose examples that reflect a global audience. For example:
-		<ul>
-			<li>When creating user stories or other examples that feature people, choose example names that come from different cultures and regions. Further guidance is provided by [[[INTERNATIONAL-SPECS]]] ([[INTERNATIONAL-SPECS]]) in the section <a data-cite="INTERNATIONAL-SPECS#personal_name_examples">Using personal names in examples</a>.</li>
-			<li>Choose more generic terms for field names, such as "postal code" instead of (U.S.-specific) "ZIP code" or "given name" instead of "first name".</li>
-		</ul>
-		<li>In general, use [=locale-neutral=] representations of data values, such as dates, numbers, currency values, and so forth.</li>
-		<!-- EDNOTE: A previous edition had a section with the id of `Dates`. The id is preserved here to avoid problems
-		     with any links to the older edition.
-		  -->
-		<li id="Dates">For time and date values, choose an unambiguous representation:
-		<ul>
-			<li>For date values that appear in prose, spell out the month (for example, <kbd>6 May 2003</kbd> or <kbd>September 23, 2016</kbd>). All numeric dates such as <kbd translate="no">5/6/03</kbd> or <kbd translate="no">6/5/03</kbd> are ambiguous. Some cultures will read the first example as "June 5" while other cultures will read the second example as that date.</li>
-			<li>For date values that appear in data, use a format derived from [[ISO8601]], such as those found in [[[RFC3339]]] [[RFC3339]] or those found in <a data-cite="XMLSchema-2#date" title="Section 3.2.9 of the XML Schema Datatypes">XML Schema Part 2: Datatypes</a></cite> ([[XMLSchema-2]], section 3.2.9).</li>
-		</ul></li>
-	</ul>
-</section>
 
 <section id="Unicode">
 <h3>Unicode</h3>
@@ -363,8 +314,7 @@ content? See also <a href="https://www.w3.org/WAI/test-evaluate/">evaluation too
 <section id="Translations">
 <h3>Translations</h3>
 
-<p>W3C has no official translations of its technical reports. W3C does
-encourage people to translate the technical reports and helps to track
+<p>W3C does encourage people to translate the technical reports and helps to track
 translators and translations.</p>
 
 <ul>
@@ -400,7 +350,7 @@ to <em lang="fr">titre</em>.</p>
 <p>Do not invent elements to replace natural language. For example, do
 not use <code>&lt;must/&gt;</code> and a style sheet to render <em class="rfc2119">M<!--informative-->UST</em>.
 Other languages may need grammatical agreement with the sentence's
-subject, <span class="not-en">e.g.</span>, in French, <em class="rfc2119">M<!--informative-->UST</em> will become
+subject, for example, in French, <em class="rfc2119">M<!--informative-->UST</em> will become
 <em xml:lang="fr" lang="fr" class="rfc2119">DOIT</em> if the subject is singular, or
 <em xml:lang="fr" lang="fr" class="rfc2119">DOIVENT</em> if it is plural. Use standard
 markup instead.</p>
@@ -409,10 +359,10 @@ markup instead.</p>
 </section>
 
 <section id="Parts">
-<h2>The Parts of a Technical Report</h2>
+<h2>The parts of a Technical Report</h2>
 
 <section id="Title">
-<h3>Document Title</h3>
+<h3>Document title</h3>
 
 <p>The title of your document in the document head and on the technical
 reports index [[TR]] will read as
@@ -426,26 +376,26 @@ information about the use of "version" and "edition". "Level" and
 "revised" are deprecated. Try not to invent a new titling
 convention.</p>
 
-<p>Capitalize title words following U.S. usage.</p>
+<p>[Placeholder for soon-published guidance or link to W3C Style Guide section on "titles for documents"]</p>
 
-<p>Only use "W3C" to start the title of your document if it describes organizational aspects of W3C, not to confuse readers about the level of endorsement from W3C (<span class="not-en">e.g.</span>, when a document is not meant to become a Recommendation or is still under development).</p>
-<p class="note">There exist exceptions to the rule, either historical (<span class="not-en">e.g.</span>, [[[XMLSCHEMA11-1]]] [[XMLSCHEMA11-1]]) or to repurpose an acronym (<span class="not-en">e.g.</span>, [[[WCAG-3.0]]] [[WCAG-3.0]]).</p>
+<p>Only use "W3C" to start the title of your document if it describes organizational aspects of W3C, not to confuse readers about the level of endorsement from W3C (for example, when a document is not meant to become a Recommendation or is still under development).</p>
+<p class="note">There exist exceptions to the rule, either historical (such as [[[XMLSCHEMA11-1]]] [[XMLSCHEMA11-1]]) or to repurpose an acronym (for example, [[[WCAG-3.0]]] [[WCAG-3.0]]).</p>
 <aside class="example" title="Documents that describe organizational aspects">
   <p>Use of "W3C" in the following titles is appropriate:</p>
   <ul>
     <li>[[[W3C-PROCESS]]] [[W3C-PROCESS]]</li>
     <li>[[[W3C-PATENT-POLICY]]] [[W3C-PATENT-POLICY]]</li>
-    <li>W3C Manual of Style (this document)</li>
+    <li>W3C Style Guide (this document)</li>
   </ul>
 </aside>
 
 </section>
 
 <section id="Editors">
-<h3>Editors and Authors</h3>
+<h3>Editors and authors</h3>
 
 <section id="affs">
-<h4>Managing Changing Affiliations</h4>
+<h4>Managing changing affiliations</h4>
 
 <p>Editor/Author affiliations change over time. Here are examples that
 illustrate the suggested approach for managing them.</p>
@@ -480,25 +430,24 @@ before at ThisCompany, and at ThatCompany)</dd>
 
 <p><dfn id="must-abstract" class="lint-ignore">Give each document an
 Abstract</dfn> (a few paragraphs at most) that summarizes what the
-document is about. The Communications Team may use the Abstract as a
+document is about. The W3C Communications Team may use the Abstract as a
 whole or in part to publicize your work. Write it for a non-technical
 audience.</p>
 </section>
 <section id="Status">
-  <h3>Status Section</h3>
+  <h3>Status section</h3>
 
 <p>The "Status of This Document" section describes the document status
 and publication context on the publication date. Pubrules
 [[PUBRULES]] states the
 requirements for the status section of each type of technical report
-(<span class="not-en">e.g.</span>, use of customized and boilerplate text).</p>
+through use of customized and boilerplate text.</p>
 
 <p>Since the status section does not change over time, express it in
-terms that will be valid over time (<span class="not-en">e.g.</span>,
-avoid the word "new"). Indicate the anticipated stability of the
+terms that will be valid over time. For example,
+avoid the word "new". Indicate the anticipated stability of the
 document while recognizing that the future is unknown. Readers are
-responsible for discovering the latest status information (<span class=
-"not-en">e.g.</span>, by following the latest version link, or visiting
+responsible for discovering the latest status information by following the latest version link, or visiting
 the W3C standards and drafts index [[TR]].</p>
 
 <p>The custom paragraph is very important as it actually contains
@@ -508,12 +457,11 @@ decide "I really should read this draft." This implies that you
 shouldn't paste it in from somewhere else. It should be very specific
 to this document.</p>
 
-<p>Tim Berners-Lee expressed the goal of the custom paragraph this way, "Don't be
-afraid of being honest about the relevant techno-political situation."
+<p>W3C founder and Web inventor Sir Tim Berners-Lee expressed the goal of the custom paragraph this way, "Don't be afraid of being honest about the relevant techno-political situation."
 In the custom paragraph, make the case for why someone should read this
 draft.</p>
 
-<p>In the custom paragraph, include what you would reply to a Member or
+<p>In the custom paragraph, include what you would reply to a W3C Member or
 colleague who asked you such things as:</p>
 
 <ul>
@@ -521,15 +469,14 @@ colleague who asked you such things as:</p>
 where should experience reports be sent?</li>
 
 <li>Are we requesting people do <em>not</em> implement the
-specification until a later date? What sort of damage do we expect to
-inflict on those who do by future changes to the document?</li>
+specification until a later date? What might happen after future changes to the document?</li>
 
 <li>Does it reflect the consensus of a W3C Working Group? (Pay
-attention to the authors and acknowledgments.)</li>
+attention to the authors and acknowledegments.)</li>
 
 <li>Are there any changes expected?</li>
 
-<li>Do we maintain a page of background information?</li>
+<li>Is there a page of background information to link to?</li>
 
 <li>For pre-release drafts, state in the status section any limits on
 redistribution, such as "Member confidential."</li>
@@ -547,18 +494,17 @@ expectation that documents in the "<abbr title=
 "technical report">TR</abbr> zone" will not evolve over time
 [[PERSISTENCE]]. For example,
 locate errata pages in the portion of the web space dedicated to the
-relevant Working Group or activity.</p>
+relevant working group or activity.</p>
 
 <p>Clearly indicate on the errata page:</p>
 
 <ul>
-<li>The last modified date for the errata page.</li>
+<li>the last modified date for the errata page</li>
 
-<li>The <abbr title="Uniform Resource Identifier">URI</abbr> of the
-source document (<span class="not-en">i.e.</span>, the one with the
-errata).</li>
+<li>the <abbr title="Uniform Resource Identifier">URI</abbr> of the
+source document (that is, the one with the errata)</li>
 
-<li>Where to find the latest version of the source document.</li>
+<li>where to find the latest version of the source document</li>
 </ul>
 
 <aside class="example" title="Front matter of an errata page">
@@ -585,26 +531,25 @@ errata).</li>
 <p>On the errata page, list the newest entries nearer to the top.</p>
 
 <section id='entries'>
-<h3>Entries on an errata
-page</h3>
+<h3>Entries on an errata page</h3>
 
 <p>For each entry on the errata page, provide:</p>
 
 <ol>
-<li>A unique identifier</li>
+<li>a unique identifier</li>
 
-<li>The date it was added to the errata page</li>
+<li>the date it was added to the errata page</li>
 
-<li>A classification of the error (<span class="not-en">e.g.</span>, editorial, clarification, bug,
+<li>a classification of the error (for example, editorial, clarification, bug,
 known problem with the document itself)</li>
 
-<li>A short description of the problem and what part of the
-Recommendation is affected.</li>
+<li>a short description of the problem and what part of the
+Recommendation is affected</li>
 
-<li>Any proposed corrections and whether those corrections would affect
+<li>any proposed corrections and whether those corrections would affect
 conformance of documents or software</li>
 
-<li>Any normative corrections; see the section on
+<li>any normative corrections; see the section on
 <a data-cite="W3C-PROCESS#errata">Errata Management in the W3C Process Document</a>
 ([[W3C-PROCESS]], section 6.2.4) for
 more information about normative corrections</li>
@@ -618,7 +563,7 @@ to be incorrect, just add another entry (with a cross reference).</p>
   <h2>References</h2>
 
 <section id="extractor">
-  <h3>Bibliography Extractor</h3>
+  <h3>Bibliography extractor</h3>
 
 <p>The <a href="https://www.specref.org/">SpecRef</a> tool, an open-source, community-maintained database of
 web standards &amp; related references, contains an exhaustive list of references.</p>
@@ -627,7 +572,7 @@ web standards &amp; related references, contains an exhaustive list of reference
 <section id="citation">
   <h3>Citation</h3>
 
-<p>Reference links (<span class="not-en">e.g.</span>, "[<abbr title=
+<p>Reference links (for example, "[<abbr title=
 "Extensible Markup Language">XML</abbr>]") link at least the first mention of a source to the References
 section and take the form:</p>
 <pre>
@@ -638,9 +583,9 @@ section and take the form:</p>
 <p>Parentheses around square brackets can be omitted unless the
 parentheses would contain a section number.</p>
 
-<p>References links occur at minimum at the first mention of the
+<p>Reference links occur at minimum at the first mention of the
 source. Spell out what the reference link refers to at least in the
-first occurrence:</p>
+first occurrence. For example:</p>
 
 <aside class="example" title="Spelling out what the reference links refers to">
 <pre>
@@ -659,18 +604,18 @@ This is discussed in [XMLName].
 </aside>
 </section>
 <section id="linking-within">
-  <h3>Citing a Reference From Within a Document</h3>
+  <h3>Citing a reference from within a document</h3>
 
-<p>When linking from the middle of the document to an external
+<p>When linking from a document to an external
 resource:</p>
 
 <ol>
-<li>Ensure that the link text, title, and context indicate you are
+<li>ensure that the link text, title, and context indicate you are
 leaving the document, and</li>
 
-<li>After the link, link to the reference in the references section,
-and indicate section, page, or whatever is useful for those when the
-link is unavailable (<span class="not-en">e.g.</span>, when printed).</li>
+<li>after the link, link to the reference in the references section,
+and indicate section, page, or whatever is useful in the case where the
+link is unavailable (for example, when printed).</li>
 </ol>
 
 <aside class="example" title="Citing a section from an external document">
@@ -680,7 +625,7 @@ link is unavailable (<span class="not-en">e.g.</span>, when printed).</li>
 </aside>
 </section>
 <section id="ref-section">
-  <h3>References Section</h3>
+  <h3>References section</h3>
 
 <ul>
 <li>All entries in a references section should be referred to in the
@@ -706,21 +651,21 @@ Model for the World Wide Web 1.0: Fundamentals</a>
 <li>An entry in a references section takes this form:
 
 <ul>
-<li>Title, inside <code>a</code> (if available), inside
+<li>title, inside <code>a</code> (if available), inside
 <code>cite</code></li>
 
-<li>Comma-delimited list of authors' names</li>
+<li>comma-delimited list of authors' names</li>
 
-<li>If there are no authors, use editors instead if available.
+<li>if there are no authors, use editors instead if available.
 Following the last family name, say "eds." or "Editors."</li>
 
-<li>Publisher, followed by the date of publication in the form DD Month
+<li>publisher, followed by the date of publication in the form DD Month
 YYYY</li>
 
-<li>A sentence containing a text-only <abbr title=
+<li>a sentence containing a text-only <abbr title=
 "Uniform Resource Identifier">URI</abbr></li>
 
-<li>When available, a sentence ending in the latest version
+<li>when available, a sentence ending in the latest version
 <abbr title="Uniform Resource Identifier">URI</abbr></li>
 </ul>
 
@@ -760,8 +705,7 @@ href="https://www.w3.org/TR/2016/REC-html51-20161101/"&gt;http://www.w3.org/TR/1
 </section>
 <section id="normative">
 
-  <h3>Normative and Informative
-References</h3>
+  <h3>Normative and informative references</h3>
 
 <p>See <a href="https://www.w3.org/guide/process/tilt/normative-references.html">Normative References</a> and considerations by the Team.</p>
 
@@ -800,7 +744,7 @@ the experts on the public mailing list <code>spec-prod@w3.org</code> [[SPEC-PROD
 <section id="Normative">
   <h2>Normative material</h2>
   <section id="N-I-sections">
-      <h3>Normative &amp; Informative sections</h3>
+      <h3>Normative &amp; informative sections</h3>
 
   <p>It is important that informative (non-normative) material
     is clearly distinguished from normative material. To this end:</p>
@@ -824,10 +768,10 @@ the experts on the public mailing list <code>spec-prod@w3.org</code> [[SPEC-PROD
 
 <section id="RFC">
   <h3><abbr title=
-"Request for Comments">RFC</abbr> 2119 Key Words</h3>
+"Request for Comments">RFC</abbr> 2119 Keywords</h3>
 
 <p>Adhere to and credit [[[RFC2119]]] [[RFC2119]]
-(<span class="not-en">e.g.</span>, "<em class="rfc2119">M<!--informative-->UST</em>", "<em class="rfc2119">M<!--informative-->UST NOT</em>", "<em class="rfc2119">R<!--informative-->EQUIRED</em>").</p>
+(such as "<em class="rfc2119">M<!--informative-->UST</em>", "<em class="rfc2119">M<!--informative-->UST NOT</em>", "<em class="rfc2119">R<!--informative-->EQUIRED</em>").</p>
 
 <p>When these key words are used in the <abbr title=
 "Request for Comments">RFC</abbr> sense, make them UPPERCASE, enclose
@@ -845,7 +789,7 @@ them in the <code>em</code> element, and style them with <abbr title=
 }
 </pre>
 
-<p>The author may explain why, if these key words are not used in the
+<p>The author may give rationale if these keywords are not used in the
 <abbr title="Request for Comments">RFC</abbr> sense.</p>
 
 <p>Where they are not <em><q cite=
@@ -853,109 +797,17 @@ them in the <code>em</code> element, and style them with <abbr title=
 interoperation or to limit behavior which has potential for causing
 harm</q></em> these key words <em><q cite=
 "https://www.rfc-editor.org/rfc/rfc2119">must not be used to try
-to impose a particular method on implementors where the method is not
+to impose a particular method on implementers where the method is not
 required for interoperability.</q></em></p>
 
 </section>
 </section>
 
 <section id="Editorial">
-  <h2>Editorial Guidelines</h2>
+  <h2>Editorial guidelines</h2>
 
-<p>This section refers to editorial practice at W3C. It touches on
-grammar, spelling, punctuation, case, linking, appearance and
-markup.</p>
+<p>Please refer to the companion W3C Style Guide [link@@] that documents W3C-specific conventions, including terminology, tone, voice, and editorial preferences. The following sections are specific to W3C specifications.</p>
 
-<section id="Grammar">
-  <h3>Grammar</h3>
-
-<ul>
-<li>Delete repeated words.</li>
-
-<li>Check subject-verb agreement.</li>
-
-<li>Break long sentences.</li>
-
-</ul>
-</section>
-<section id="Spelling">
-  <h3>Spelling</h3>
-
-<ul>
-<li>Spell-check using a U.S. English dictionary. Append ",spell" to a
-W3C <abbr title="Uniform Resource Identifier">URI</abbr> to invoke
-W3C's spell checker.</li>
-
-<li>Free dictionaries are also available on the [[[ISPELL]]] home page
-[[ISPELL]] for UNIX and Mac OS.</li>
-
-<li>W3C uses [[[M-W]]] [[M-W]] on the web as the spelling
-arbiter because it is free, online, and available to every technical
-report author and editor. </li>
-
-<li>W3C uses U.S. English (<span class="not-en">e.g.</span>,
-"standardise" should read "standardize" and "colour" should read
-"color").</li>
-
-<li>Form the plural of abbreviations, initialisms and acronyms without
-an apostrophe (<span class="not-en">e.g.</span>, the plural of
-<abbr title="Uniform Resource Identifier">URI</abbr> is <abbr title=
-"Uniform Resource Identifiers">URIs</abbr> not <abbr title=
-"Uniform Resource Identifiers">URI's</abbr>). See the FAQ
-[[[PLURAL]]] [[PLURAL]].</li>
-</ul>
-</section>
-<section id="Punctuation">
-  <h3>Punctuation</h3>
-
-<ul>
-<li>Use correct punctuation. A hard copy of [[[CHICAGO]]] [[CHICAGO]] or
-  [[[GREGG]]] [[GREGG]] may be of some help.
-<ul>
-	<li>Exception: Em dash
-		<ul>
-			<li>Put a space before and after an em dash.</li>
-		</ul>
-	</li>
-</ul>
-</li>
-
-<li>Remember you are typing <abbr title=
-"HyperText Markup Language">HTML</abbr> or <abbr title=
-"Extensible Markup Language">XML</abbr> not TeX. Use quotation marks
-rather than grave accents and apostrophes to quote text (<span class=
-"not-en">e.g.</span>, ``value'' should read "value").</li>
-</ul>
-
-</section>
-<section id="Case">
-  <h3>Case, Combining Words, and Hyphenation</h3>
-
-<ul>
-<li>Capitalize W3C entities to match the [[[W3C-PROCESS]]] [[W3C-PROCESS]]
-(<span class="not-en">e.g.</span>, Working Group, Recommendation).</li>
-
-<li>Make the case, number of words, and hyphenation in terms match
-<a href="#Terms">chapter 13</a>.</li>
-</ul>
-
-</section>
-<section id="Misc">
-  <h3>Miscellaneous</h3>
-
-<ul>
-<li>Spell out acronyms and initialisms in their first occurrence in
-prose, for example, "Internet Engineering Task Force
-(<abbr>IETF</abbr>)" or "Internationalization (<abbr>I18N</abbr>)." In
-subsequent occurrences when they do not need to be spelled out, use
-<code>abbr</code> elements, and give them
-<code>title</code> attributes.</li>
-
-<li>Check references (most commonly, for no full stop after the
-<span class="not-en" xml:lang="la" lang="la">et</span> in et al.). </li>
-</ul>
-
-</section>
 <section id="Linking">
   <h3>Linking</h3>
 
@@ -964,13 +816,13 @@ subsequent occurrences when they do not need to be spelled out, use
 always refer to specific W3C documents by using the "this version"
 <abbr title="Uniform Resource Identifier">URI</abbr>.</li>
 
-<li>If you are referring to a W3C document using either its this
-version or latest version <abbr title=
+<li>If you are referring to a W3C document using either its "this
+version" or "latest version" <abbr title=
 "Uniform Resource Identifier">URI</abbr>, note whether the <abbr title=
 "Uniform Resource Identifier">URI</abbr> ends in a slash or not. These
 identifiers do not end in an extension such as "<kbd>.html</kbd>".
 Include the extension when intentionally referring to a specific
-version (<span class="not-en">e.g.</span>, a <abbr title=
+version (for example, a <abbr title=
 "Graphics Interchange Format">GIF</abbr> image where <abbr title=
 "Graphics Interchange Format">GIF</abbr> and <abbr title=
 "Portable Network Graphics">PNG</abbr> are both available through
@@ -981,7 +833,7 @@ content negotiation).</li>
 </ul>
 </section>
 <section id="Examples">
-  <h3>Using Examples</h3>
+  <h3>Using examples</h3>
 
 <ul>
 <li>Domains in examples adhere to section 3, "Reserved Example Second
@@ -1014,7 +866,7 @@ copyrighted materials, it should contact the Team legal staff (team-legal@w3.org
 <code>div</code> elements to mark up examples, as is done in the
 <a data-cite="HTML/semantics.html#document-metadata"
 title="Section 4.2. Document metadata">HTML Living Standard</a>
-([[HTML]], section 4.2):</p>
+([[HTML]], section 4.2).</p>
 </li>
 </ul>
 
@@ -1026,9 +878,9 @@ title="Section 4.2. Document metadata">HTML Living Standard</a>
 <li>We recommend that each image be available as PNG, even if you use
 content negotiation to serve alternative formats.</li>
 
-<li>Give images a background color (<span class="not-en">e.g.</span>,
+<li>Give images a background color (for example,
 white) so your technical report can be read with any style sheet
-(<span class="not-en">e.g.</span>, with W3C's dark on light style
+(for example, with W3C's dark on light style
 sheets, or a user style sheet that specifies a dark background).</li>
 
 <li>Match image size to markup <code>width</code> and
@@ -1077,7 +929,7 @@ element for <abbr title=
 page.</li>
 
 <li>Make semantic distinctions using more than only color, for example,
-a font-style change, so that color-blind individuals can see a
+a font-style change, so that people who cannot distinguish between certain colors (often called “color blindness”) can see a
 difference.</li>
 
 <li>Links with the anchor text "Click here" provide no context. The
@@ -1090,7 +942,7 @@ bolding a <code>td</code>.</li>
 
 </section>
 <section id="Large">
-  <h3>Large Documents</h3>
+  <h3>Large documents</h3>
 
 <p>Large single files that may be easy to print and search may not be
 easy to download. For large documents:</p>
@@ -1103,43 +955,16 @@ files.</li>
 specification. This format may be compressed if large.</li>
 
 <li>You can offer an archived version (zip, tar, tgz) of the separate
-files. Provide all necessary file in archived versions including the
+files. Provide all necessary files in archived versions including the
 relevant style sheets. Don't link to images or style sheets not
 included in the archive.</li>
 </ul>
 
 </section>
-<section id="inclusive">
-  <h3>Inclusive terminology</h3>
-
-<p>Following the <a
-  href="https://www.w3.org/policies/code-of-conduct/#expected-behavior">W3C Code of Conduct</a>,
-<abbr title="World Wide Web Consortium">W3C</abbr> specifications are expected to be
-inclusive and facilitate diversity. As such, editors and authors are strongly encouraged
-to use a neutral and inclusive language to ensure the best environment possible for the
-whole <abbr title="World Wide Web Consortium">W3C</abbr> community.</p>
-
-<p>Here are proposed alternatives for some terms that <a
-  href="https://www.w3.org/pubrules/">PubRules</a> (see <a
-  href="https://www.w3.org/pubrules/badterms.json">list of terms in JSON</a>) shows a
-warning about:</p>
-
-<table id="neutrallanguage" class="data">
-  <thead>
-    <tr>
-      <th>Terms to avoid</th>
-      <th>Possible alternatives</th>
-    </tr>
-  </thead>
-  <tbody>
-  </tbody>
-</table>
-
-</section>
 
 </section>
 <section id="MediaTypes">
-  <h2>Internet Media Types</h2>
+  <h2>Internet media types</h2>
 
 <ul>
 <li>For information about defining a new Internet media type (formerly known as <abbr title="Multipurpose Internet Mail Extensions">MIME</abbr> type) in your specification, see [[[REGISTER-1]]] [[REGISTER-1]].</li>
@@ -1148,248 +973,7 @@ warning about:</p>
 </ul>
 
 </section>
-<section id="Terms">
-  <h2>Commonly Misspelled Terms</h2>
 
-<p>W3C has reviewed its technical reports one by one since November
-1999, for typographical errors. The following words appear often in
-those reviews.</p>
-
-<dl class="terms">
-<dt>anti-alias</dt>
-
-<dd>hyphenate</dd>
-
-<dt><abbr title=
-"American Standard Code for Information Interchange">ASCII</abbr></dt>
-
-<dd>all caps</dd>
-
-<dt>base64</dt>
-
-<dd>lowercase, one word</dd>
-
-<dt>Bézier</dt>
-
-<dd>always capitalize, and accent the first e</dd>
-
-<dt>braille</dt>
-
-<dd>capitalize only when talking about Louis Braille</dd>
-
-<dt>built-in</dt>
-
-<dd>hyphenate when used as an adjective or noun, not when built is a
-verb</dd>
-
-<dt>color space</dt>
-
-<dd>two words</dd>
-
-<dt><abbr title="document type definition">DTDs</abbr></dt>
-
-<dd>no apostrophe [[PLURAL]]</dd>
-
-<dt>dingbat</dt>
-
-<dd>one word</dd>
-
-<dt>ebook</dt>
-
-<dd>Lowercase "b", one work, no hyphen</dd>
-	
-<dt>ECMAScript</dt>
-
-<dd>one word, cap S</dd>
-
-<dt><span xml:lang="la" lang="la">et al.</span></dt>
-
-<dd>no <span class="UnicodeName">full stop</span> after "et"</dd>
-
-<dt><span class="UnicodeName">full stop</span> (.)</dt>
-
-<dd><span class="UnicodeName">Full stop</span> is the formal name.
-<span class="UnicodeAlias">Dot</span> and <span class=
-"UnicodeAlias">period</span> are good aliases.</dd>
-
-<dt><span class="UnicodeName">hash</span> (#)</dt>
-
-<dd>also <span class="UnicodeAlias">number sign</span>, usually not <span class="UnicodeAlias">pound sign</span>, <span class="UnicodeAlias">crosshatch</span> or <span class="UnicodeAlias">octothorpe</span></dd>
-
-<dt>heading</dt>
-
-<dd>Term for <code>h1</code>-<code>h6</code>. Tables and HTTP have
-headers.</dd>
-
-<dt>HTTP/1.0</dt>
-
-<dd>needs slash when referred to as a protocol, none in free text</dd>
-
-<dt>HTTP/1.1</dt>
-
-<dd>needs slash when referred to as a protocol, none in free text</dd>
-
-<dt>homepage, home page</dt>
-
-<dd>one word preferred, both allowed</dd>
-
-<dt>Java</dt>
-
-<dd>cap J</dd>
-
-<dt>JavaScript</dt>
-
-<dd>cap S</dd>
-
-<dt>Level 1, 2, 3</dt>
-
-<dd>cap L when referring to a W3C technical report</dd>
-
-<dt>line feed</dt>
-
-<dd>two words</dd>
-
-<dt>lowercase</dt>
-
-<dd>one word</dd>
-
-<dt>markup</dt>
-
-<dd>one word when used as a noun, two words when used as a verb</dd>
-
-<dt><abbr title="Multipurpose Internet Mail Extensions">MIME</abbr> type</dt>
-
-<dd>now Internet media type (MIME type is two words. MIME is all caps.)</dd>
-
-<dt>namespace</dt>
-
-<dd>lowercase unless referring to the [[[xml-names]]] [[xml-names]]
-specification by name</dd>
-
-<dt><span class="UnicodeName">number sign</span> (#)</dt>
-
-<dd>also <span class="UnicodeAlias">hash</span>, usually not <span class="UnicodeAlias">pound sign</span>, <span class="UnicodeAlias">crosshatch</span> or <span class="UnicodeAlias">octothorpe</span></dd>
-
-<dt>online</dt>
-
-<dd>one word, no hyphen</dd>
-
-<dt>PDF</dt>
-
-<dd>all caps</dd>
-
-<dt>PostScript</dt>
-
-<dd>cap S</dd>
-
-<dt>read-only</dt>
-
-<dd>hyphenate</dd>
-
-<dt>Real-Time Communication, real-time communication, real-time communications, RTC</dt>
-
-<dd>In titles and headings, capitalize all words = Real-Time Communication</dd>
-<dd>For the generic idea in sentences, lowercase = real-time communication or real-time communications &mdash; including with the acronym = real-time communications (RTC)</dd>
-
-<dt>ruby</dt>
-
-<dd>lowercase for the typographic convention. Uppercase for the programming language.</dd>
-
-<dt>schema</dt>
-
-<dd>lowercase</dd>
-
-<dt>schemas</dt>
-
-<dd>preferred to schemata</dd>
-
-<dt>semicolon</dt>
-
-<dd>one word</dd>
-
-<dt>standalone, stand-alone</dt>
-
-<dd>one word preferred, both allowed</dd>
-
-<dt>stylesheet, style sheet</dt>
-
-<dd>two words preferred, both allowed</dd>
-
-<dt>subset</dt>
-
-<dd>no hyphen</dd>
-
-<dt>superset</dt>
-
-<dd>no hyphen</dd>
-
-<dt>uppercase</dt>
-
-<dd>one word</dd>
-
-<dt><abbr title="Uniform Resource Identifier">URI</abbr> reference</dt>
-
-<dd>usually not <abbr title="Uniform Resource Identifier">URI</abbr>
-Reference or <abbr title=
-"Uniform Resource Identifier">URI</abbr>-Reference</dd>
-
-<dt><abbr title="Uniform Resource Identifiers">URIs</abbr></dt>
-
-<dd>no apostrophe [[PLURAL]]</dd>
-
-<dt>user agent</dt>
-
-<dd>lowercase</dd>
-
-<dt>user interface</dt>
-
-<dd>lowercase</dd>
-
-<dt>web (on its own)</dt>
-
-<dd>lowercase</dd>
-
-<dt>Web (as part of a phrase)
-
-<dd>always capitalize in "World Wide Web", "World Wide Web Consortium", "Web Consortium"</dd>
-
-<dt>Webmaster, webmaster</dt>
-
-<dd>one word, either capitalize or lowercase</dd>
-
-<dt>webpage, web page</dt>
-
-<dd>both allowed, lowercase "web"</dd>
-
-<dt>website, web site</dt>
-
-<dd>one word preferred, both allowed. lowercase "web"</dd>
-
-<dt>well-formed</dt>
-
-<dd>hyphenate</dd>
-
-<dt>white space</dt>
-
-<dd>two words</dd>
-
-<dt>worldwide</dt>
-
-<dd>one word</dd>
-
-<dt>World Wide Web</dt>
-
-<dd>three words, no hyphen</dd>
-
-<dt>W3C, the World Wide Web Consortium, the Web Consortium</dt>
-<dd>refer to us as "the World Wide Web Consortium", "the Web Consortium", or "W3C" but not "the W3C"</dd>
-<dd>when using the acronym, treat it as a proper noun and use "W3C" but not "the W3C" unless it's used as an adjective, <span class="not-en">e.g.</span>, "The W3C Team is small but mighty"</dd>
-
-<dt>W3C Note</dt>
-
-<dd>not W3C NOTE</dd>
-</dl>
-</section>
 <section id="ACK">
   <h2>Acknowledgments</h2>
 

--- a/manual-of-style/index.html
+++ b/manual-of-style/index.html
@@ -71,7 +71,7 @@
         },
         "IPRFAQ": {
           href: "https://www.w3.org/copyright/intellectual-rights/",
-          title: "Intellectual Property <abbr title='Frequently Asked Questions list'>FAQ</abbr>",
+          title: "Intellectual Property FAQ",
           publisher: "W3C",
           date: "2024"
         },
@@ -179,7 +179,7 @@
 
 <p>Written for editors and authors of W3C technical reports, this
 document assumes that the reader is familiar with the
-W3C Style Guide [when ready, add link via 'localBiblio]. It is a companion to the
+W3C Style Guide [when ready, add link via 'localBiblio']. It is a companion to the
 mandatory [[[PUBRULES]]] [[PUBRULES]],
 called "pubrules" for short. 
 
@@ -385,7 +385,8 @@ convention.</p>
   <ul>
     <li>[[[W3C-PROCESS]]] [[W3C-PROCESS]]</li>
     <li>[[[W3C-PATENT-POLICY]]] [[W3C-PATENT-POLICY]]</li>
-    <li>W3C Style Guide (this document)</li>
+    <li>W3C Style Guide [when ready, add link via 'localBiblio']</li>li>
+    <li>W3C Specification Editor Handbook (this document)</li>
   </ul>
 </aside>
 

--- a/manual-of-style/index.html
+++ b/manual-of-style/index.html
@@ -385,7 +385,7 @@ convention.</p>
   <ul>
     <li>[[[W3C-PROCESS]]] [[W3C-PROCESS]]</li>
     <li>[[[W3C-PATENT-POLICY]]] [[W3C-PATENT-POLICY]]</li>
-    <li>W3C Style Guide [when ready, add link via 'localBiblio']</li>li>
+    <li>W3C Style Guide [when ready, add link via 'localBiblio']</li>
     <li>W3C Specification Editor Handbook (this document)</li>
   </ul>
 </aside>

--- a/manual-of-style/index.html
+++ b/manual-of-style/index.html
@@ -473,7 +473,7 @@ where should experience reports be sent?</li>
 specification until a later date? What might happen after future changes to the document?</li>
 
 <li>Does it reflect the consensus of a W3C Working Group? (Pay
-attention to the authors and acknowledegments.)</li>
+attention to the authors and acknowledgments.)</li>
 
 <li>Are there any changes expected?</li>
 

--- a/manual-of-style/index.html
+++ b/manual-of-style/index.html
@@ -218,7 +218,7 @@ that documents are valid before requesting publication.</p>
 <section id="Accessibility">
 <h2>Accessibility</h2>
 
-<p></p>Follow the [[[WCAG]]] [[WCAG]]. See also [[[WCAG-Overview]]]
+<p>Follow the [[[WCAG]]] [[WCAG]]. See also [[[WCAG-Overview]]]
   [[WCAG-Overview]] for an introduction to the guidelines. Can
 simpler words express your ideas? Is your text marked up with
 structural elements? Are alternatives provided for auditory and visual

--- a/manual-of-style/index.html
+++ b/manual-of-style/index.html
@@ -455,7 +455,7 @@ the W3C standards and drafts index [[TR]].</p>
 information! In it, you should explain where a part of the energy of
 the group has been invested. The custom paragraph should help a reader
 decide "I really should read this draft." This implies that you
-shouldn't paste it in from somewhere else. It should be very specific
+should not paste it in from somewhere else. It should be very specific
 to this document.</p>
 
 <p>W3C founder and Web inventor Sir Tim Berners-Lee expressed the goal of the custom paragraph this way, "Don't be afraid of being honest about the relevant techno-political situation."
@@ -567,7 +567,7 @@ to be incorrect, just add another entry (with a cross reference).</p>
   <h3>Bibliography extractor</h3>
 
 <p>The <a href="https://www.specref.org/">SpecRef</a> tool, an open-source, community-maintained database of
-web standards &amp; related references, contains an exhaustive list of references.</p>
+web standards and related references, contains an exhaustive list of references.</p>
 
 </section>
 <section id="citation">
@@ -745,10 +745,10 @@ the experts on the public mailing list <code>spec-prod@w3.org</code> [[SPEC-PROD
 <section id="Normative">
   <h2>Normative material</h2>
   <section id="N-I-sections">
-      <h3>Normative &amp; informative sections</h3>
+      <h3>Normative and informative sections</h3>
 
   <p>It is important that informative (non-normative) material
-    is clearly distinguished from normative material. To this end:</p>
+    is clearly distinguished from normative material. To this end, ensure the following:</p>
     <ul>
       <li>If the entire document is informative, say so at the top and
         do not reference RFC 2119 or use <a href="#RFC">RFC 2119 keywords</a>
@@ -887,10 +887,9 @@ sheets, or a user style sheet that specifies a dark background).</li>
 <li>Match image size to markup <code>width</code> and
 <code>height</code> (or images will be distorted).</li>
 
-<li>See the <a href="https://www.w3.org/TR/WCAG20-TECHS/">Web Content Accessibility
-Guidelines Techniques</a> for information about providing alternative
+<li>See the <a href="https://www.w3.org/WAI/WCAG22/Techniques/">Techniques for <abbr title="Web Content Accessibility Guidelines">WCAG</abbr>&nbsp;2.2</a> for information about providing alternative
 text (<code>alt</code>) and long descriptions (<code>longdesc</code>)
-for images. Also, don't forget to spell-check your alternative
+for images. Also, do not forget to spell-check your alternative
 text.</li>
 </ul>
 
@@ -957,7 +956,7 @@ specification. This format may be compressed if large.</li>
 
 <li>You can offer an archived version (zip, tar, tgz) of the separate
 files. Provide all necessary files in archived versions including the
-relevant style sheets. Don't link to images or style sheets not
+relevant style sheets. Do not link to images or style sheets not
 included in the archive.</li>
 </ul>
 


### PR DESCRIPTION
Stripped the document of everything that is covered in the companion unified W3C Style Guide

TODO before merge:
rename or move the current index.html once we know the new URL, then do the merge, then setup redirects


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/guide/pull/445.html" title="Last updated on Sep 14, 2026, 10:17 AM UTC (1856f10)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/guide/445/05c4ac9...1856f10.html" title="Last updated on Sep 14, 2026, 10:17 AM UTC (1856f10)">Diff</a>